### PR TITLE
feat: Enable non azure bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,4 @@ resources that lack official modules.
 | <a name="output_storage_container"></a> [storage\_container](#output\_storage\_container) | n/a |
 | <a name="output_url"></a> [url](#output\_url) | The URL to the W&B application |
 <!-- END_TF_DOCS -->
+


### PR DESCRIPTION
Bump module version because last MR didn't do it.