### PR TITLE
fix: Add perms for ingress to update the public subnet as well

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,7 @@ module "app_aks" {
   location       = azurerm_resource_group.default.location
 
   gateway           = module.app_lb.gateway
+  public_subnet     = module.networking.public_subnet
   cluster_subnet_id = module.networking.private_subnet.id
 
   tags = var.tags

--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -56,3 +56,9 @@ resource "azurerm_role_assignment" "resource_group" {
   role_definition_name = "Reader"
   principal_id         = local.ingress_gateway_principal_id
 }
+
+resource "azurerm_role_assignment" "gateway" {
+  scope                = var.public_subnet.id
+  role_definition_name = "Contributor"
+  principal_id         = local.ingress_gateway_principal_id
+}

--- a/modules/app_aks/variables.tf
+++ b/modules/app_aks/variables.tf
@@ -22,6 +22,10 @@ variable "gateway" {
   type = object({ id = string })
 }
 
+variable "public_subnet" {
+  type = object({ id = string })
+}
+
 variable "tags" {
   default     = {}
   type        = map(string)


### PR DESCRIPTION
I created a new cluster, but its application gateway did not have the right listeners. After lots of digging around, I went into the ingress* pod and found the following logs:
```
E1003 23:59:28.456537       1 controller.go:141] network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="ApplicationGatewayInsufficientPermissionOnSubnet" Message="Client with object id 4a0f8c94-3307-45ce-aa28-8910e9dc0f1f does not have permission on the Virtual Network resource /subscriptions/c9dd8162-c274-4935-87d7-ccdb4b856b10/resourceGroups/testing-yo-lt02/providers/Microsoft.Network/virtualNetworks/testing-yo-lt02-vpc/subnets/testing-yo-lt02-public to perform action Microsoft.Network/virtualNetworks/subnets/join/action. For details on the required permissions, please visit https://aka.ms/agsubnetjoin." Details=[]
E1003 23:59:28.456557       1 worker.go:62] Error processing event.network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="ApplicationGatewayInsufficientPermissionOnSubnet" Message="Client with object id 4a0f8c94-3307-45ce-aa28-8910e9dc0f1f does not have permission on the Virtual Network resource /subscriptions/c9dd8162-c274-4935-87d7-ccdb4b856b10/resourceGroups/testing-yo-lt02/providers/Microsoft.Network/virtualNetworks/testing-yo-lt02-vpc/subnets/testing-yo-lt02-public to perform action Microsoft.Network/virtualNetworks/subnets/join/action. For details on the required permissions, please visit https://aka.ms/agsubnetjoin." Details=[]
I1003 23:59:28.456784       1 event.go:282] Event(v1.ObjectReference{Kind:"Pod", Namespace:"kube-system", Name:"ingress-appgw-deployment-5c5967d8b7-fgx62", UID:"1282d6ba-3344-4baf-bc84-ed5137166edd", APIVersion:"v1", ResourceVersion:"1088", FieldPath:""}): type: 'Warning' reason: 'FailedApplyingAppGwConfig' network.ApplicationGatewaysClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="ApplicationGatewayInsufficientPermissionOnSubnet" Message="Client with object id 4a0f8c94-3307-45ce-aa28-8910e9dc0f1f does not have permission on the Virtual Network resource /subscriptions/c9dd8162-c274-4935-87d7-ccdb4b856b10/resourceGroups/testing-yo-lt02/providers/Microsoft.Network/virtualNetworks/testing-yo-lt02-vpc/subnets/testing-yo-lt02-public to perform action Microsoft.Network/virtualNetworks/subnets/join/action. For details on the required permissions, please visit https://aka.ms/agsubnetjoin." Details=[]
```
This indicates that the AGIC now updates the public subnet too. Giving it the right permissions worked like a charm!