### PR TITLE
fix: Source extraEnv from other_wandb_env variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,6 +186,7 @@ module "wandb" {
         }
 
         extraEnv = var.other_wandb_env
+        
       }
             
       app = {

--- a/main.tf
+++ b/main.tf
@@ -184,6 +184,8 @@ module "wandb" {
           password = module.redis.instance.primary_access_key
           port     = module.redis.instance.port
         }
+
+        extraEnv = var.other_wandb_env
       }
             
       app = {


### PR DESCRIPTION
Testing:
In a test instance, I specified:
```

  other_wandb_env = {
    WANDB_FOO = "bar"
  }

```
Then inspected after plan and apply:
```
$ kubectl exec -it wandb-app-8b9757b7b-ndw4v --context testing-yo-lt01-cluster -- env | sort | grep -i foo
Defaulted container "app" out of: app, init-db (init)
WANDB_FOO=bar

$ kubectl exec -it wandb-weave-7554fc5867-cqzdq --context testing-yo-lt01-cluster -- env | sort | grep -i 
foo
WANDB_FOO=bar

$ kubectl exec -it wandb-parquet-54b56fd688-vp7ws --context testing-yo-lt01-cluster -- env | sort | grep -
i foo
WANDB_FOO=bar
```