### PR TITLE
feat: Storage account blob soft deletion

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -14,6 +14,9 @@ resource "azurerm_storage_account" "default" {
       exposed_headers    = ["*"]
       max_age_in_seconds = 3600
     }
+    delete_retention_policy {
+      days = 30
+    }
   }
 
   queue_properties {


### PR DESCRIPTION
Fixes WB-16037

# Description

Deleting data is risky. To make sure we can recover accidentally deleted files, we enable blob soft deletion with 30 day retention.

We block artifact garbage collection until blob soft deletion is enabled.

Relevant docs: https://learn.microsoft.com/en-us/azure/storage/blobs/soft-delete-blob-enable

# Test plan

TBD