### PR TITLE
chore: Add encryption at rest to AKS clusters

### DIFF
--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -43,6 +43,10 @@ resource "azurerm_kubernetes_cluster" "default" {
   lifecycle {
     ignore_changes = [microsoft_defender]
   }
+
+  key_management_service {
+    key_vault_key_id = azurerm_key_vault_key.etcd.id
+  }
 }
 
 locals {

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -50,3 +50,19 @@ resource "azurerm_key_vault_access_policy" "identity" {
 
   depends_on = [azurerm_key_vault.default]
 }
+
+resource "azurerm_key_vault_key" "etcd" {
+  name         = "generated-etcd-key"
+  key_vault_id = azurerm_key_vault.default.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}


### PR DESCRIPTION
AKS does not encrypt Kubernetes Secrets at rest by default.  This PR generates a key, and configures the AKS cluster to use it for etcd encryption.