### PR TITLE
fix: Fix deletion protection for Azure storage

### DIFF
--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -38,7 +38,7 @@ resource "azurerm_storage_container" "default" {
 resource "azurerm_management_lock" "default" {
   count      = var.deletion_protection ? 1 : 0
   name       = "${var.namespace}-container"
-  scope      = azurerm_storage_container.default.id
+  scope      = azurerm_storage_account.default.id
   lock_level = "CanNotDelete"
   notes      = "Deletion protection is enabled on the storage container."
 }


### PR DESCRIPTION
It is not possible lock the container, only Storage accounts

https://learn.microsoft.com/en-us/azure/storage/common/lock-account-resource?tabs=portal

To protect the container, broader research must determine if using an `Immutability policy on a container` can resolve this topic.

https://learn.microsoft.com/en-us/azure/storage/blobs/data-protection-overview

But Terraform AzureRM don't support container immutability policies yet.

https://github.com/hashicorp/terraform-provider-azurerm/issues/3722

In the same issue above, there's a solution based on `az_api` provider that eventually can help if the solution is `Immutability policy` 