### PR TITLE
fix: Set the Azure sku_tier to standard for AKS clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ resources that lack official modules.
 | <a name="input_allowed_ip_ranges"></a> [allowed\_ip\_ranges](#input\_allowed\_ip\_ranges) | allowed public IP addresses or CIDR ranges. | `list(string)` | `[]` | no |
 | <a name="input_app_wandb_env"></a> [app\_wandb\_env](#input\_app\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_blob_container"></a> [blob\_container](#input\_blob\_container) | Use an existing bucket. | `string` | `""` | no |
-| <a name="input_cluster_sku_tier"></a> [cluster\_sku\_tier](#input\_cluster\_sku\_tier) | n/a | `string` | `"Free"` | no |
+| <a name="input_cluster_sku_tier"></a> [cluster\_sku\_tier](#input\_cluster\_sku\_tier) | The Azure AKS SKU Tier to use for this cluster (https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers) | `string` | `"Free"` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_availability_mode"></a> [database\_availability\_mode](#input\_database\_availability\_mode) | n/a | `string` | `"SameZone"` | no |
 | <a name="input_database_sku_name"></a> [database\_sku\_name](#input\_database\_sku\_name) | Specifies the SKU Name for this MySQL Server | `string` | `"GP_Standard_D4ds_v4"` | no |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ resources that lack official modules.
 | <a name="input_allowed_ip_ranges"></a> [allowed\_ip\_ranges](#input\_allowed\_ip\_ranges) | allowed public IP addresses or CIDR ranges. | `list(string)` | `[]` | no |
 | <a name="input_app_wandb_env"></a> [app\_wandb\_env](#input\_app\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_blob_container"></a> [blob\_container](#input\_blob\_container) | Use an existing bucket. | `string` | `""` | no |
+| <a name="input_cluster_sku_tier"></a> [cluster\_sku\_tier](#input\_cluster\_sku\_tier) | n/a | `string` | `"Free"` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
 | <a name="input_database_availability_mode"></a> [database\_availability\_mode](#input\_database\_availability\_mode) | n/a | `string` | `"SameZone"` | no |
 | <a name="input_database_sku_name"></a> [database\_sku\_name](#input\_database\_sku\_name) | Specifies the SKU Name for this MySQL Server | `string` | `"GP_Standard_D4ds_v4"` | no |

--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ module "app_aks" {
   node_pool_vm_size     = var.kubernetes_instance_type
   public_subnet         = module.networking.public_subnet
   resource_group        = azurerm_resource_group.default
-
+  sku_tier              = var.cluster_sku_tier
   tags = var.tags
 }
 

--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -3,7 +3,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = var.location
   resource_group_name = var.resource_group.name
   dns_prefix          = var.namespace
-  sku_tier            = "Standard"
+  sku_tier            = var.sku_tier
 
   automatic_channel_upgrade         = "stable"
   role_based_access_control_enabled = true

--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -3,6 +3,7 @@ resource "azurerm_kubernetes_cluster" "default" {
   location            = var.location
   resource_group_name = var.resource_group.name
   dns_prefix          = var.namespace
+  sku_tier            = "Standard"
 
   automatic_channel_upgrade         = "stable"
   role_based_access_control_enabled = true

--- a/modules/app_aks/variables.tf
+++ b/modules/app_aks/variables.tf
@@ -52,5 +52,5 @@ variable "node_pool_vm_count" {
 
 variable "sku_tier" {
   type = string
-  default = "Standard"
+  default = "Free"
 }

--- a/modules/app_aks/variables.tf
+++ b/modules/app_aks/variables.tf
@@ -49,3 +49,8 @@ variable "node_pool_vm_size" {
 variable "node_pool_vm_count" {
   type = number
 }
+
+variable "sku_tier" {
+  type = string
+  default = "Standard"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -212,5 +212,6 @@ variable "parquet_wandb_env" {
 
 variable "cluster_sku_tier" {
   type = string
+  description = "The Azure AKS SKU Tier to use for this cluster (https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers)"
   default = "Free"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -210,3 +210,7 @@ variable "parquet_wandb_env" {
   default     = {}
 }
 
+variable "cluster_sku_tier" {
+  type = string
+  default = "Free"
+}


### PR DESCRIPTION
We need to explicitly set the sku_tier as the default is not right for us.

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#sku_tier
https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers