### PR TITLE
fix: Make max pods configurabe and return default to 30 for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ resources that lack official modules.
 | <a name="input_license"></a> [license](#input\_license) | Your wandb/local license | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | String used for prefix resources. | `string` | n/a | yes |
+| <a name="input_node_max_pods"></a> [node\_max\_pods](#input\_node\_max\_pods) | Maximum number of pods per node | `number` | `30` | no |
 | <a name="input_oidc_auth_method"></a> [oidc\_auth\_method](#input\_oidc\_auth\_method) | OIDC auth method | `string` | `"implicit"` | no |
 | <a name="input_oidc_client_id"></a> [oidc\_client\_id](#input\_oidc\_client\_id) | The Client ID of application in your identity provider | `string` | `""` | no |
 | <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | A url to your Open ID Connect identity provider, i.e. https://cognito-idp.us-east-1.amazonaws.com/us-east-1_uiIFNdacd | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ module "app_aks" {
   public_subnet         = module.networking.public_subnet
   resource_group        = azurerm_resource_group.default
   sku_tier              = var.cluster_sku_tier
+  max_pods              = var.node_max_pods
   tags = var.tags
 }
 

--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -19,7 +19,7 @@ resource "azurerm_kubernetes_cluster" "default" {
 
   default_node_pool {
     enable_auto_scaling         = false
-    max_pods                    = 60
+    max_pods                    = var.max_pods
     name                        = "default"
     node_count                  = var.node_pool_vm_count
     temporary_name_for_rotation = "rotating"

--- a/modules/app_aks/variables.tf
+++ b/modules/app_aks/variables.tf
@@ -54,3 +54,9 @@ variable "sku_tier" {
   type = string
   default = "Free"
 }
+
+variable "max_pods" {
+  type = number
+  description = "Maximum number of pods per node"
+  default = 30
+}

--- a/variables.tf
+++ b/variables.tf
@@ -221,3 +221,9 @@ variable "azuremonitor" {
   type = bool
   default = true
 }
+
+variable "node_max_pods" {
+  type = number
+  description = "Maximum number of pods per node"
+  default = 30
+}


### PR DESCRIPTION
Due to current subnet size there are issues changing this to be higher, go back to old value and make it a variable so we can test different values.