### PR TITLE
fix: Make default node pool zone configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ resources that lack official modules.
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | String used for prefix resources. | `string` | n/a | yes |
 | <a name="input_node_max_pods"></a> [node\_max\_pods](#input\_node\_max\_pods) | Maximum number of pods per node | `number` | `30` | no |
+| <a name="input_node_pool_zones"></a> [node\_pool\_zones](#input\_node\_pool\_zones) | Availability zones for the node pool | `list(string)` | <pre>[<br>  "1",<br>  "2"<br>]</pre> | no |
 | <a name="input_oidc_auth_method"></a> [oidc\_auth\_method](#input\_oidc\_auth\_method) | OIDC auth method | `string` | `"implicit"` | no |
 | <a name="input_oidc_client_id"></a> [oidc\_client\_id](#input\_oidc\_client\_id) | The Client ID of application in your identity provider | `string` | `""` | no |
 | <a name="input_oidc_issuer"></a> [oidc\_issuer](#input\_oidc\_issuer) | A url to your Open ID Connect identity provider, i.e. https://cognito-idp.us-east-1.amazonaws.com/us-east-1_uiIFNdacd | `string` | `""` | no |

--- a/examples/custom-tf-with-existing-resources/main.tf
+++ b/examples/custom-tf-with-existing-resources/main.tf
@@ -15,7 +15,7 @@ provider "helm" {
   kubernetes {
     host                   = data.azurerm_kubernetes_cluster.cluster.kube_config.0.host
     cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config.0.cluster_ca_certificate)
-    client_key             =  base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config.0.client_key)
+    client_key             = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config.0.client_key)
     client_certificate     = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config.0.client_certificate)
   }
 }
@@ -30,7 +30,7 @@ locals {
   public_subnet  = data.azurerm_subnet.public
   resource_group = data.azurerm_resource_group.group
   vault_uri      = var.vault_uri
-  identity_id = data.azurerm_user_assigned_identity.identity.client_id
+  identity_id    = data.azurerm_user_assigned_identity.identity.client_id
 }
 
 
@@ -139,7 +139,7 @@ module "wandb" {
         }
         serviceAccount = {
           name        = local.service_account_name
-          annotations = { "azure.workload.identity/client-id" = local.identity_id}
+          annotations = { "azure.workload.identity/client-id" = local.identity_id }
           labels      = { "azure.workload.identity/use" = "true" }
         }
       }

--- a/examples/custom-tf-with-existing-resources/variables.tf
+++ b/examples/custom-tf-with-existing-resources/variables.tf
@@ -192,8 +192,8 @@ variable "redis_env" {
 
 variable "aks_cluster_name" {
   nullable = false
-  type    = string
-  default = "**"
+  type     = string
+  default  = "**"
 }
 
 variable "identity_name" {

--- a/examples/custom-tf-with-vpc-sql/variables.tf
+++ b/examples/custom-tf-with-vpc-sql/variables.tf
@@ -1,11 +1,11 @@
 variable "subscription_id" {
   nullable = false
-  type    = string
-  default = ""
+  type     = string
+  default  = ""
 }
 
 variable "namespace" {
-  nullable = false
+  nullable    = false
   type        = string
   description = "String used for prefix resources."
   default     = ""
@@ -49,11 +49,11 @@ variable "wandb_image" {
 variable "license" {
   type        = string
   description = "Your wandb/local license"
-  default = ""
-  }
+  default     = ""
+}
 
 variable "database_sku_name" {
-  type = string
+  type        = string
   default     = "GP_Standard_D4ds_v4"
   description = "Specifies the SKU Name for this MySQL Server"
 }
@@ -131,22 +131,22 @@ variable "parquet_wandb_env" {
 }
 
 variable "vpc_name" {
-  nullable = false
+  nullable    = false
   description = "virtual network name"
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "private_subnet" {
   nullable = false
-  type    = string
-  default = ""
+  type     = string
+  default  = ""
 }
 
 variable "public_subnet" {
   nullable = false
-  type    = string
-  default = ""
+  type     = string
+  default  = ""
 }
 
 variable "kubernetes_instance_type" {
@@ -163,16 +163,16 @@ variable "kubernetes_node_count" {
 variable "database_env" {
   nullable = false
   type = object({
-    host = string
-    username = string
-    password = string
+    host          = string
+    username      = string
+    password      = string
     database_name = string
   })
 
   default = {
-    host     = "**.mysql.database.azure.com"
-    username     = "**"
-    password = "**"
+    host          = "**.mysql.database.azure.com"
+    username      = "**"
+    password      = "**"
     database_name = "**"
   }
 }

--- a/examples/standard-tf/main.tf
+++ b/examples/standard-tf/main.tf
@@ -25,9 +25,9 @@ provider "helm" {
 module "wandb" {
   source = "../../"
 
-  namespace   = var.namespace
-  location    = var.location
-  license     = var.license
+  namespace = var.namespace
+  location  = var.location
+  license   = var.license
 
   domain_name = var.domain_name
   subdomain   = var.subdomain
@@ -36,21 +36,21 @@ module "wandb" {
   wandb_image   = var.wandb_image
 
   database_sku_name = var.database_sku_name
-  database_version = var.database_version
+  database_version  = var.database_version
 
-  create_redis       = true
-  use_internal_queue = true
-  ssl = var.ssl
-  deletion_protection = true
+  create_redis          = true
+  use_internal_queue    = true
+  ssl                   = var.ssl
+  deletion_protection   = true
   kubernetes_node_count = var.kubernetes_node_count
-  
-  storage_account = var.storage_account
-  blob_container = var.blob_container
-  storage_key = var.storage_key
-  external_bucket  = var.external_bucket
 
-  weave_wandb_env = var.weave_wandb_env
-  app_wandb_env = var.app_wandb_env
+  storage_account = var.storage_account
+  blob_container  = var.blob_container
+  storage_key     = var.storage_key
+  external_bucket = var.external_bucket
+
+  weave_wandb_env   = var.weave_wandb_env
+  app_wandb_env     = var.app_wandb_env
   parquet_wandb_env = var.parquet_wandb_env
 
   tags = var.tags

--- a/examples/standard-tf/variables.tf
+++ b/examples/standard-tf/variables.tf
@@ -6,7 +6,7 @@ variable "subscription_id" {
 variable "namespace" {
   type        = string
   description = "String used for prefix resources."
-  default = ""
+  default     = ""
 }
 
 variable "location" {
@@ -22,7 +22,7 @@ variable "oidc_issuer" {
 
 variable "domain_name" {
   type        = string
-  default = ""
+  default     = ""
   description = "Domain for accessing the Weights & Biases UI."
 }
 
@@ -47,8 +47,8 @@ variable "wandb_image" {
 variable "license" {
   type        = string
   description = "Your wandb/local license"
-  default = ""
-  }
+  default     = ""
+}
 
 
 variable "tags" {

--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,9 @@ resource "azurerm_resource_group" "default" {
 }
 
 module "identity" {
-  source = "./modules/identity"
+  source         = "./modules/identity"
   namespace      = var.namespace
-  otel_identity = var.azuremonitor
+  otel_identity  = var.azuremonitor
   resource_group = azurerm_resource_group.default
   location       = azurerm_resource_group.default.location
 }
@@ -107,11 +107,12 @@ module "app_aks" {
   namespace             = var.namespace
   node_pool_vm_count    = var.kubernetes_node_count
   node_pool_vm_size     = var.kubernetes_instance_type
+  node_pool_zones       = var.node_pool_zones
   public_subnet         = module.networking.public_subnet
   resource_group        = azurerm_resource_group.default
   sku_tier              = var.cluster_sku_tier
   max_pods              = var.node_max_pods
-  tags = var.tags
+  tags                  = var.tags
 }
 
 locals {
@@ -147,7 +148,7 @@ resource "azurerm_role_assignment" "otel_role" {
   scope                = azurerm_resource_group.default.id
   role_definition_name = "Contributor"
   principal_id         = module.identity.otel_identity.principal_id
-   
+
 }
 
 resource "azurerm_federated_identity_credential" "otel_app" {

--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_kubernetes_cluster" "default" {
     type                        = "VirtualMachineScaleSets"
     vm_size                     = var.node_pool_vm_size
     vnet_subnet_id              = var.cluster_subnet_id
-    zones                       = ["1", "2"]
+    zones                       = var.node_pool_zones
   }
 
   identity {

--- a/modules/app_aks/variables.tf
+++ b/modules/app_aks/variables.tf
@@ -51,12 +51,18 @@ variable "node_pool_vm_count" {
 }
 
 variable "sku_tier" {
-  type = string
+  type    = string
   default = "Free"
 }
 
 variable "max_pods" {
-  type = number
+  type        = number
   description = "Maximum number of pods per node"
-  default = 30
+  default     = 30
+}
+
+variable "node_pool_zones" {
+  type        = list(string)
+  description = "Availability zones for the node pool"
+  default     = ["1", "2"]
 }

--- a/modules/identity/main.tf
+++ b/modules/identity/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_user_assigned_identity" "default" {
 }
 
 resource "azurerm_user_assigned_identity" "otel" {
-  count = var.otel_identity ? 1 : 0
+  count               = var.otel_identity ? 1 : 0
   name                = "${var.namespace}-identity-otel"
   location            = var.location
   resource_group_name = var.resource_group.name

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -83,5 +83,5 @@ resource "azurerm_subnet_network_security_group_association" "public" {
   count                     = length(var.allowed_ip_ranges) > 0 ? 1 : 0
   subnet_id                 = azurerm_subnet.public.id
   network_security_group_id = azurerm_network_security_group.default.0.id
-  depends_on = [ azurerm_network_security_rule.default ]
+  depends_on                = [azurerm_network_security_rule.default]
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -57,5 +57,5 @@ variable "tags" {
 
 variable "allowed_ip_ranges" {
   description = "allowed public IP addresses or CIDR ranges."
-  type = list(string)
+  type        = list(string)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -181,6 +181,11 @@ variable "kubernetes_node_count" {
   type    = number
 }
 
+variable "node_pool_zones" {
+  type        = list(string)
+  description = "Availability zones for the node pool"
+  default     = ["1", "2"]
+}
 ##########################################
 # Network                                #
 ##########################################
@@ -188,7 +193,7 @@ variable "kubernetes_node_count" {
 variable "allowed_ip_ranges" {
   description = "allowed public IP addresses or CIDR ranges."
   type        = list(string)
-  default = []
+  default     = []
 }
 
 
@@ -211,19 +216,19 @@ variable "parquet_wandb_env" {
 }
 
 variable "cluster_sku_tier" {
-  type = string
+  type        = string
   description = "The Azure AKS SKU Tier to use for this cluster (https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers)"
-  default = "Free"
+  default     = "Free"
 }
 
 ## To support otel azure monitor sql and redis metrics need operator-wandb chart minimum version 0.14.0 
 variable "azuremonitor" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "node_max_pods" {
-  type = number
+  type        = number
   description = "Maximum number of pods per node"
-  default = 30
+  default     = 30
 }


### PR DESCRIPTION
fix: Make default node pool zone configurable

This may help to workaround situations like this
```
Error: creating Kubernetes Cluster (Subscription: "c213eb8e-d0e7-4bbb-985a-2f8deac5c1c5" Resource Group Name: "wandb-hitachi" Kubernetes Cluster Name: "wandb-hitachi-cluster"): managedclusters.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="BadRequest" Message="The VM size of Standard_D4s_v3 is only allowed in zones [3 1] in your subscription in location 'japaneast'. "
with module.wandb.module.app_aks.azurerm_kubernetes_cluster.default
on .terraform/modules/wandb/modules/app_aks/main.tf line 1, in resource "azurerm_kubernetes_cluster" "default":
resource "azurerm_kubernetes_cluster" "default" {
```