### PR TITLE
feat: Add optional path var for instance level bucket path 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ resources that lack official modules.
 
 ## Inputs
 
+<<<<<<< HEAD
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_ip_ranges"></a> [allowed\_ip\_ranges](#input\_allowed\_ip\_ranges) | Allowed public IP addresses or CIDR ranges. | `list(string)` | `[]` | no |
@@ -75,6 +76,7 @@ resources that lack official modules.
 | <a name="input_app_wandb_env"></a> [app\_wandb\_env](#input\_app\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_azuremonitor"></a> [azuremonitor](#input\_azuremonitor) | # To support otel azure monitor sql and redis metrics need operator-wandb chart minimum version 0.14.0 | `bool` | `false` | no |
 | <a name="input_blob_container"></a> [blob\_container](#input\_blob\_container) | Use an existing bucket. | `string` | `""` | no |
+| <a name="input_bucket_path"></a> [bucket\_path](#input\_bucket\_path)                                                   | path of where to store data for the instance-level bucket                                                                                | `string`      | `""` | no |
 | <a name="input_cluster_sku_tier"></a> [cluster\_sku\_tier](#input\_cluster\_sku\_tier) | The Azure AKS SKU Tier to use for this cluster (https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers) | `string` | `"Free"` | no |
 | <a name="input_create_private_link"></a> [create\_private\_link](#input\_create\_private\_link) | Use for the azure private link. | `bool` | `false` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ resources that lack official modules.
 
 ## Inputs
 
-<<<<<<< HEAD
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_ip_ranges"></a> [allowed\_ip\_ranges](#input\_allowed\_ip\_ranges) | Allowed public IP addresses or CIDR ranges. | `list(string)` | `[]` | no |
@@ -76,7 +75,7 @@ resources that lack official modules.
 | <a name="input_app_wandb_env"></a> [app\_wandb\_env](#input\_app\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_azuremonitor"></a> [azuremonitor](#input\_azuremonitor) | # To support otel azure monitor sql and redis metrics need operator-wandb chart minimum version 0.14.0 | `bool` | `false` | no |
 | <a name="input_blob_container"></a> [blob\_container](#input\_blob\_container) | Use an existing bucket. | `string` | `""` | no |
-| <a name="input_bucket_path"></a> [bucket\_path](#input\_bucket\_path)                                                   | path of where to store data for the instance-level bucket                                                                                | `string`      | `""` | no |
+| <a name="input_bucket_path"></a> [bucket\_path](#input\_bucket\_path) | path of where to store data for the instance-level bucket | `string` | `""` | no |
 | <a name="input_cluster_sku_tier"></a> [cluster\_sku\_tier](#input\_cluster\_sku\_tier) | The Azure AKS SKU Tier to use for this cluster (https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers) | `string` | `"Free"` | no |
 | <a name="input_create_private_link"></a> [create\_private\_link](#input\_create\_private\_link) | Use for the azure private link. | `bool` | `false` | no |
 | <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |

--- a/examples/public-dns/main.tf
+++ b/examples/public-dns/main.tf
@@ -41,6 +41,8 @@ module "wandb" {
 
   deletion_protection = false
 
+  bucket_path = var.bucket_path
+
   tags = {
     "Example" : "PublicDns"
   }

--- a/examples/public-dns/variables.tf
+++ b/examples/public-dns/variables.tf
@@ -52,3 +52,9 @@ variable "database_sku_name" {
   default     = "GP_Standard_D4ds_v4"
   description = "Specifies the SKU Name for this MySQL Server"
 }
+
+variable "bucket_path" {
+  description = "path of where to store data for the instance-level bucket"
+  type        = string
+  default     = ""
+}

--- a/main.tf
+++ b/main.tf
@@ -222,7 +222,7 @@ locals {
   default_bucket_config = {
     provider  = "az"
     name      = var.storage_account
-    path      = var.blob_container
+    path      = "${var.blob_container}/${var.bucket_path}"
     accessKey = var.storage_key
   }
   bucket_config = var.external_bucket != null ? var.external_bucket : (local.use_customer_bucket ? local.default_bucket_config : null)
@@ -250,13 +250,13 @@ module "wandb" {
         bucket        = local.bucket_config == null ?  {
           provider  = "az"
           name      = module.storage[0].account.name
-          path      = module.storage[0].container.name + "/" + var.bucket_path
+          path      = "${module.storage[0].container.name}/${var.bucket_path}"
           accessKey = module.storage[0].account.primary_access_key
         } : local.bucket_config
         defaultBucket = {
           provider  = "az"
           name      = module.storage[0].account.name
-          path      = module.storage[0].container.name + "/" + var.bucket_path
+          path      = "${module.storage[0].container.name}/${var.bucket_path}"
           accessKey = module.storage[0].account.primary_access_key
         }
         azureIdentityForBucket = {

--- a/main.tf
+++ b/main.tf
@@ -250,13 +250,13 @@ module "wandb" {
         bucket        = local.bucket_config == null ?  {
           provider  = "az"
           name      = module.storage[0].account.name
-          path      = module.storage[0].container.name
+          path      = module.storage[0].container.name + "/" + var.bucket_path
           accessKey = module.storage[0].account.primary_access_key
         } : local.bucket_config
         defaultBucket = {
           provider  = "az"
           name      = module.storage[0].account.name
-          path      = module.storage[0].container.name
+          path      = module.storage[0].container.name + "/" + var.bucket_path
           accessKey = module.storage[0].account.primary_access_key
         }
         azureIdentityForBucket = {

--- a/variables.tf
+++ b/variables.tf
@@ -180,6 +180,17 @@ variable "external_bucket" {
   default     = null
 }
 
+##########################################
+# Bucket path                            #
+##########################################
+# This setting is meant for users who want to store all of their instance-level
+# bucket's data at a specific path within their bucket. It can be set both for
+# external buckets or the bucket created by this module.
+variable "bucket_path" {
+  description = "path of where to store data for the instance-level bucket"
+  type        = string
+  default     = ""
+}
 
 ##########################################
 # K8s                                    #


### PR DESCRIPTION
Below the TF plan are the updated env vars

**TF plan:**
```
Terraform will perform the following actions:

  # module.wandb.module.app_aks.azurerm_kubernetes_cluster.default will be updated in-place
  ~ resource "azurerm_kubernetes_cluster" "default" {
...

      ~ default_node_pool {
            name                         = "default"
            tags                         = {}
            # (24 unchanged attributes hidden)

          - upgrade_settings {
              - drain_timeout_in_minutes      = 0 -> null
              - max_surge                     = "10%" -> null
              - node_soak_duration_in_minutes = 0 -> null
            }
        }

        # (6 unchanged blocks hidden)
    }

  # module.wandb.module.wandb.helm_release.wandb will be updated in-place
  ~ resource "helm_release" "wandb" {
        id                         = "wandb-cr"
      ~ metadata                   = [
          - {
              - app_version    = "1.0.0"
              - chart          = "wandb-cr"
              - first_deployed = 1724465197
              - last_deployed  = 1724465197
              - name           = "wandb-cr"
              - namespace      = "default"
              - notes          = ""
              - revision       = 1
              - values         = jsonencode(
                    {
                      - name = "wandb"
                      - spec = <<-EOT
                            "values":
                              "app":
...
                                "bucket":
                                  "accessKey": "<redacted>"
                                  "name": "levinaztwostorage"
                                  "path": "wandb"
                                  "provider": "az"
                                "cloudProvider": "azure"
  ...
                        EOT
                    }
                )
              - version        = "0.1.0"
            },
        ] -> (known after apply)
        name                       = "wandb-cr"
        # (26 unchanged attributes hidden)

...

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```

**Updated env vars:**
```
wandb@wandb-app-6cc8d6b764-p55qm:~$ env | grep -i nested
BUCKET=az://levinaztwostorage/wandb/nested/path
    "store": "az://levinaztwostorage/wandb/nested/path",
OVERFLOW_BUCKET_ADDR=az://levinaztwostorage/wandb/nested/path
GORILLA_FILE_STORE=az://levinaztwostorage/wandb/nested/path
GORILLA_STORAGE_BUCKET=az://levinaztwostorage/wandb/nested/path
```