### PR TITLE
fix!: Expose externalized redis to helm for console metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ resources that lack official modules.
 | <a name="input_cluster_sku_tier"></a> [cluster\_sku\_tier](#input\_cluster\_sku\_tier) | The Azure AKS SKU Tier to use for this cluster (https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers) | `string` | `"Free"` | no |
 | <a name="input_controller_image_tag"></a> [controller\_image\_tag](#input\_controller\_image\_tag) | Tag of the controller image to deploy | `string` | `"1.14.0"` | no |
 | <a name="input_create_private_link"></a> [create\_private\_link](#input\_create\_private\_link) | Use for the azure private link. | `bool` | `false` | no |
-| <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `false` | no |
+| <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Boolean indicating whether to provision an redis instance (true) or not (false). | `bool` | `true` | no |
 | <a name="input_database_availability_mode"></a> [database\_availability\_mode](#input\_database\_availability\_mode) | n/a | `string` | `"SameZone"` | no |
 | <a name="input_database_sku_name"></a> [database\_sku\_name](#input\_database\_sku\_name) | Specifies the SKU Name for this MySQL Server. Defaults to null and value from deployment-size.tf is used | `string` | `null` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Version for MySQL | `string` | `"5.7"` | no |

--- a/main.tf
+++ b/main.tf
@@ -420,7 +420,10 @@ module "wandb" {
       }
 
       mysql = { install = false }
-      redis = { install = false }
+      redis = {
+        install = !var.create_redis && !var.use_external_redis
+        external = var.use_external_redis
+      }
 
       parquet = {
         extraEnv = var.parquet_wandb_env

--- a/main.tf
+++ b/main.tf
@@ -322,14 +322,17 @@ module "wandb" {
         redis = var.use_external_redis ? {
           host = var.external_redis_host
           port = var.external_redis_port
+          external = true
           } : var.create_redis ? {
           host     = module.redis[0].instance.hostname
           password = module.redis[0].instance.primary_access_key
           port     = module.redis[0].instance.port
+          external = false
           } : {
           host     = null
           password = null
           port     = null
+          external = false
         }
 
         extraEnv = var.other_wandb_env
@@ -420,10 +423,7 @@ module "wandb" {
       }
 
       mysql = { install = false }
-      redis = {
-        install = false
-        external = var.use_external_redis
-      }
+      redis = { install = false }
 
       parquet = {
         extraEnv = var.parquet_wandb_env

--- a/main.tf
+++ b/main.tf
@@ -421,7 +421,7 @@ module "wandb" {
 
       mysql = { install = false }
       redis = {
-        install = !var.create_redis && !var.use_external_redis
+        install = false
         external = var.use_external_redis
       }
 

--- a/main.tf
+++ b/main.tf
@@ -327,12 +327,10 @@ module "wandb" {
           host     = module.redis[0].instance.hostname
           password = module.redis[0].instance.primary_access_key
           port     = module.redis[0].instance.port
-          external = false
           } : {
           host     = null
           password = null
           port     = null
-          external = false
         }
 
         extraEnv = var.other_wandb_env

--- a/variables.tf
+++ b/variables.tf
@@ -161,7 +161,7 @@ variable "database_sku_name" {
 variable "create_redis" {
   type        = bool
   description = "Boolean indicating whether to provision an redis instance (true) or not (false)."
-  default     = false
+  default     = true
 }
 
 variable "redis_capacity" {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the caching service configuration to automatically control installation based on deployment settings.
  - Introduced a new option that allows you to connect to an external caching service when required.
  - Updated the default behavior to provision a Redis instance automatically unless overridden by the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->