### PR TITLE
fix: Tag cache_size on cloud managed K8s

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2023 Weights & Biases
+		Copyright 2023 Weights & Biases
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ resources that lack official modules.
 | <a name="input_azuremonitor"></a> [azuremonitor](#input\_azuremonitor) | # To support otel azure monitor sql and redis metrics need operator-wandb chart minimum version 0.14.0 | `bool` | `false` | no |
 | <a name="input_blob_container"></a> [blob\_container](#input\_blob\_container) | Use an existing bucket. | `string` | `""` | no |
 | <a name="input_bucket_path"></a> [bucket\_path](#input\_bucket\_path) | path of where to store data for the instance-level bucket | `string` | `""` | no |
+| <a name="input_cache_size"></a> [cache\_size](#input\_cache\_size) | Size of the redis cache, when use\_ctrlplane\_redis is true. These values map to preset sizes in the bitnami helm chart. | `string` | `"nano"` | no |
 | <a name="input_clickhouse_private_endpoint_service_name"></a> [clickhouse\_private\_endpoint\_service\_name](#input\_clickhouse\_private\_endpoint\_service\_name) | ClickHouse private endpoint 'Service name' (ends in .azure.privatelinkservice). | `string` | `""` | no |
 | <a name="input_clickhouse_region"></a> [clickhouse\_region](#input\_clickhouse\_region) | ClickHouse region (eastus2, westus3, etc). | `string` | `""` | no |
 | <a name="input_cluster_sku_tier"></a> [cluster\_sku\_tier](#input\_cluster\_sku\_tier) | The Azure AKS SKU Tier to use for this cluster (https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers) | `string` | `"Free"` | no |

--- a/main.tf
+++ b/main.tf
@@ -159,7 +159,7 @@ module "app_aks" {
   public_subnet           = module.networking.public_subnet
   resource_group          = azurerm_resource_group.default
   sku_tier                = var.cluster_sku_tier
-  tags                    = var.tags
+  tags                    = merge(var.tags, {cache_size = var.cache_size})
 }
 locals {
   service_account_name         = "wandb-app"

--- a/variables.tf
+++ b/variables.tf
@@ -206,7 +206,15 @@ variable "use_ctrlplane_redis" {
   default     = false
 }
 
-
+variable "cache_size" {
+  description = "Size of the redis cache, when use_ctrlplane_redis is true. These values map to preset sizes in the bitnami helm chart."
+  type        = string
+  default     = "nano"
+  validation {
+    condition     = contains(["nano", "micro", "small", "medium", "large", "xlarge", "2xlarge"], var.cache_size)
+    error_message = "Invalid value specified for 'cache_size'; must be one of 'nano', 'micro', 'small', 'medium', 'large'"
+  }
+}
 
 ##########################################
 # External Bucket                        #


### PR DESCRIPTION
- INFRA-673 apply cache_size tag to AKS cluster
- empty


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option enabling users to select a preset Redis cache size.
  - Enhanced resource metadata tagging to reflect the chosen cache configuration.
- **Documentation**
  - Updated user documentation with details regarding the new cache size option.
- **Style**
  - Refined the visual formatting of the displayed copyright notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->