### PR TITLE
fix: Bump k8s max nodes by 2

### DIFF
--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -4,35 +4,35 @@ locals {
     small = {
       db             = "MO_Standard_E2ds_v4",
       min_node_count = 1,
-      max_node_count = 2,
+      max_node_count = 4,
       node_instance  = "Standard_E4s_v5"
       cache          = "3"
     },
     medium = {
       db             = "MO_Standard_E4ds_v4",
       min_node_count = 1,
-      max_node_count = 2,
+      max_node_count = 4,
       node_instance  = "Standard_E4s_v5"
       cache          = "3"
     },
     large = {
       db             = "MO_Standard_E8ds_v4",
       min_node_count = 1,
-      max_node_count = 2,
+      max_node_count = 4,
       node_instance  = "Standard_E8s_v5"
       cache          = "4"
     },
     xlarge = {
       db             = "MO_Standard_E16ds_v4",
       min_node_count = 1,
-      max_node_count = 2,
+      max_node_count = 4,
       node_instance  = "Standard_E8s_v5"
       cache          = "4"
     },
     xxlarge = {
       db             = "MO_Standard_E32ds_v4",
       min_node_count = 1,
-      max_node_count = 3,
+      max_node_count = 5,
       node_instance  = "Standard_E16s_v5"
       cache          = "5"
     }


### PR DESCRIPTION
The max k8s nodes setting is controlled in `deployment-size.tf` and is not defaulted in `core/../{aws,azure,google}/*.tf` nor `terraform-{aws,google,azurerm}-wandb/{main,variables}.tf`.

Recent platform incidents demonstrated that mass-pod replacement may fail for max node counts < 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded deployment capacity by increasing the maximum allowable resource limits across various configuration sizes.  
  - Users now benefit from enhanced scalability and improved performance when handling heavier workloads, as deployments can support a greater number of nodes.  
  - Overall, this update delivers a more robust and flexible solution for managing increased resource demands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->