### PR TITLE
fix: Use vars in secure_storage_connector examples

### DIFF
--- a/examples/secure-storage-connector/main.tf
+++ b/examples/secure-storage-connector/main.tf
@@ -1,17 +1,17 @@
 provider "azurerm" {
   features {}
-  subscription_id = "26c54111-ca63-4feb-a59e-e70beb7f72eb"
-  tenant_id       = "df6b81d4-a363-4352-b652-f7e584129264"
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
 }
 
 
 
 module "secure_storage_connector" {
   source              = "../../modules/secure_storage_connector"
-  namespace           = "zacharyblasczyk"
-  resource_group_name = "zacharyblasczyk"
-  oidc_issuer_url     = "https://eastus.oic.prod-aks.azure.com/af722783-84b6-4adc-9c49-c792786eab4a/ba51b00b-03ae-4850-a8c4-beaa5f0bd79e/"
-  deletion_protection = false
+  namespace           = var.namespace
+  resource_group_name = var.resource_group_name
+  oidc_issuer_url     = var.oidc_issuer_url
+  deletion_protection = var.deletion_protection
 }
 
 output "storage_account_name" {

--- a/examples/secure-storage-connector/variables.tf
+++ b/examples/secure-storage-connector/variables.tf
@@ -26,5 +26,5 @@ variable "oidc_issuer_url" {
 variable "deletion_protection" {
   type        = bool
   description = "If the instance should have deletion protection enabled. The storage container can't be deleted when this value is set to `true`"
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
Plan output
```
❯ terraform apply                                                                   7s  3.9.9 ﴃ W&B Test Tenant 03:58:54 PM
module.secure_storage_connector.data.azurerm_resource_group.group: Reading...
module.secure_storage_connector.data.azurerm_client_config.current: Reading...
module.secure_storage_connector.data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD0wNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDY7b2JqZWN0SWQ9YWVjMTRjNmUtNjFlZS00YWUxLWJkMGMtMTM3NDVjMmEyNmEyO3N1YnNjcmlwdGlvbklkPTI2YzU0MTExLWNhNjMtNGZlYi1hNTllLWU3MGJlYjdmNzJlYjt0ZW5hbnRJZD1kZjZiODFkNC1hMzYzLTQzNTItYjY1Mi1mN2U1ODQxMjkyNjQ=]
module.secure_storage_connector.data.azurerm_resource_group.group: Read complete after 1s [id=/subscriptions/26c54111-ca63-4feb-a59e-e70beb7f72eb/resourceGroups/test-ex-fix]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.secure_storage_connector.azurerm_federated_identity_credential.sa_map["api"] will be created
  + resource "azurerm_federated_identity_credential" "sa_map" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "<REDACTED>"
      + name                = "multi-fed-cred-federated-credential-wandb-api"
      + parent_id           = (known after apply)
      + resource_group_name = "test-ex-fix"
      + subject             = "system:serviceaccount:default:wandb-api"
    }

  # module.secure_storage_connector.azurerm_federated_identity_credential.sa_map["app"] will be created
  + resource "azurerm_federated_identity_credential" "sa_map" {
      + audience            = [
          + "api://AzureADTokenExchange",
        ]
      + id                  = (known after apply)
      + issuer              = "<REDACTED>"
      + name                = "multi-fed-cred-federated-credential-wandb-app"
      + parent_id           = (known after apply)
      + resource_group_name = "test-ex-fix"
      + subject             = "system:serviceaccount:default:wandb-app"
    }

...

  # module.secure_storage_connector.azurerm_role_assignment.account will be created
  + resource "azurerm_role_assignment" "account" {
      + condition_version                = (known after apply)
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = (known after apply)
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "Storage Account Contributor"
      + scope                            = (known after apply)
      + skip_service_principal_aad_check = (known after apply)
    }

  # module.secure_storage_connector.azurerm_role_assignment.container will be created
  + resource "azurerm_role_assignment" "container" {
      + condition_version                = (known after apply)
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = (known after apply)
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "Storage Blob Data Owner"
      + scope                            = (known after apply)
      + skip_service_principal_aad_check = (known after apply)
    }

  # module.secure_storage_connector.azurerm_user_assigned_identity.default will be created
  + resource "azurerm_user_assigned_identity" "default" {
      + client_id           = (known after apply)
      + id                  = (known after apply)
      + location            = "southcentralus"
      + name                = "multi-fed-cred-identity"
      + principal_id        = (known after apply)
      + resource_group_name = "test-ex-fix"
      + tenant_id           = (known after apply)
    }

  # module.secure_storage_connector.module.storage.azurerm_storage_account.default will be created
  + resource "azurerm_storage_account" "default" {
      + access_tier                        = (known after apply)
      + account_kind                       = "StorageV2"
      + account_replication_type           = "ZRS"
      + account_tier                       = "Standard"
      + allow_nested_items_to_be_public    = true
      + cross_tenant_replication_enabled   = false
      + default_to_oauth_authentication    = false
      + dns_endpoint_type                  = "Standard"
      + https_traffic_only_enabled         = true
      + id                                 = (known after apply)
      + infrastructure_encryption_enabled  = false
      + is_hns_enabled                     = false
      + large_file_share_enabled           = (known after apply)
      + local_user_enabled                 = true
      + location                           = "southcentralus"
      + min_tls_version                    = "TLS1_2"
      + name                               = "multifedcredstorage"
      + nfsv3_enabled                      = false
      + primary_access_key                 = (sensitive value)
...
      + secondary_web_microsoft_host       = (known after apply)
      + sftp_enabled                       = false
      + shared_access_key_enabled          = true
      + table_encryption_key_type          = "Service"

      + blob_properties {
          + change_feed_enabled      = false
          + default_service_version  = (known after apply)
          + last_access_time_enabled = false
          + versioning_enabled       = false

          + cors_rule {
              + allowed_headers    = [
                  + "*",
                ]
              + allowed_methods    = [
                  + "GET",
                  + "HEAD",
                  + "PUT",
                ]
              + allowed_origins    = [
                  + "*",
                ]
              + exposed_headers    = [
                  + "*",
                ]
              + max_age_in_seconds = 3600
            }
        }

      + queue_properties {
          + logging {
              + delete                = true
              + read                  = true
              + retention_policy_days = 10
              + version               = "1.0"
              + write                 = true
            }
        }
    }

  # module.secure_storage_connector.module.storage.azurerm_storage_container.default will be created
  + resource "azurerm_storage_container" "default" {
      + container_access_type             = "private"
      + default_encryption_scope          = (known after apply)
      + encryption_scope_override_enabled = true
      + has_immutability_policy           = (known after apply)
      + has_legal_hold                    = (known after apply)
      + id                                = (known after apply)
      + metadata                          = (known after apply)
      + name                              = "multi-fed-cred"
      + resource_manager_id               = (known after apply)
      + storage_account_name              = "multifedcredstorage"
    }

Plan: 18 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + managed_identity_client_id = (known after apply)
  + storage_account_name       = "multifedcredstorage"
  + storage_container_name     = "multi-fed-cred"
  + tenant_id                  = "<REDACTED>"
╷
│ Warning: Argument is deprecated
│
│   with module.secure_storage_connector.module.storage.azurerm_storage_account.default,
│   on ../../modules/storage/main.tf line 5, in resource "azurerm_storage_account" "default":
│    5: resource "azurerm_storage_account" "default" {
│
│ this block has been deprecated and superseded by the `azurerm_storage_account_queue_properties` resource and will be removed in v5.0 of the AzureRM provider
│
│ (and 2 more similar warnings elsewhere)
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes
```