### PR TITLE
chore: Add weave-worker-auth secret generation

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -94,7 +94,7 @@ resource "kubernetes_secret" "weave_worker_auth" {
     name = "weave-worker-auth"
   }
 
-  data = {
+  string_data = {
     key = random_password.weave_worker_auth.result
   }
 


### PR DESCRIPTION
This PR adds the three following tasks:

- generate a random token
- store the token in KeyVault
- store the token as a Kubernetes secret

This token is used by the new Weave worker to make authenticated requests to Gorilla. The token needs to be present in KeyVault for Gorilla (Gorilla reads the secret from KeyVault at runtine) and as a Kubernetes secret to interpolated as an env var in the Weave worker Helm chart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new randomly generated password for enhanced security.
  * The password is securely stored in Azure Key Vault and also made available as a Kubernetes secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->