### PR TITLE
feat: Add adjustable root volumes sizes and defaults by deployment size

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ resources that lack official modules.
 | <a name="input_kubernetes_instance_type"></a> [kubernetes\_instance\_type](#input\_kubernetes\_instance\_type) | Instance type for primary node group. Defaults to null and value from deployment-size.tf is used | `string` | `null` | no |
 | <a name="input_kubernetes_max_node_per_az"></a> [kubernetes\_max\_node\_per\_az](#input\_kubernetes\_max\_node\_per\_az) | Maximum number of nodes for the AKS cluster. Defaults to null and value from deployment-size.tf is used | `number` | `null` | no |
 | <a name="input_kubernetes_min_node_per_az"></a> [kubernetes\_min\_node\_per\_az](#input\_kubernetes\_min\_node\_per\_az) | Minimum number of nodes for the AKS cluster. Defaults to null and value from deployment-size.tf is used | `number` | `null` | no |
+| <a name="input_kubernetes_node_disk_size_gb"></a> [kubernetes\_node\_disk\_size\_gb](#input\_kubernetes\_node\_disk\_size\_gb) | Size of the node root volume in GB. | `number` | `"100"` | no |
 | <a name="input_license"></a> [license](#input\_license) | Your wandb/local license | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | String used for prefix resources. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ resources that lack official modules.
 | <a name="input_kubernetes_instance_type"></a> [kubernetes\_instance\_type](#input\_kubernetes\_instance\_type) | Instance type for primary node group. Defaults to null and value from deployment-size.tf is used | `string` | `null` | no |
 | <a name="input_kubernetes_max_node_per_az"></a> [kubernetes\_max\_node\_per\_az](#input\_kubernetes\_max\_node\_per\_az) | Maximum number of nodes for the AKS cluster. Defaults to null and value from deployment-size.tf is used | `number` | `null` | no |
 | <a name="input_kubernetes_min_node_per_az"></a> [kubernetes\_min\_node\_per\_az](#input\_kubernetes\_min\_node\_per\_az) | Minimum number of nodes for the AKS cluster. Defaults to null and value from deployment-size.tf is used | `number` | `null` | no |
-| <a name="input_kubernetes_node_disk_size_gb"></a> [kubernetes\_node\_disk\_size\_gb](#input\_kubernetes\_node\_disk\_size\_gb) | Size of the node root volume in GB. | `number` | `"100"` | no |
+| <a name="input_kubernetes_node_disk_size_gb"></a> [kubernetes\_node\_disk\_size\_gb](#input\_kubernetes\_node\_disk\_size\_gb) | Size of the node root volume in GB. | `number` | `null` | no |
 | <a name="input_license"></a> [license](#input\_license) | Your wandb/local license | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | String used for prefix resources. | `string` | n/a | yes |

--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -7,7 +7,7 @@ locals {
       max_node_count   = 4,
       node_instance    = "Standard_E8s_v5"
       cache            = "3"
-      root_volume_size = 100
+      root_volume_size = 128
     },
     medium = {
       db               = "MO_Standard_E4ds_v4",
@@ -15,7 +15,7 @@ locals {
       max_node_count   = 4,
       node_instance    = "Standard_E16s_v5"
       cache            = "3"
-      root_volume_size = 100
+      root_volume_size = 128
     },
     large = {
       db               = "MO_Standard_E8ds_v4",

--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -10,35 +10,35 @@ locals {
       root_volume_size = 100
     },
     medium = {
-      db             = "MO_Standard_E4ds_v4",
-      min_node_count = 1,
-      max_node_count = 4,
-      node_instance  = "Standard_E16s_v5"
-      cache          = "3"
+      db               = "MO_Standard_E4ds_v4",
+      min_node_count   = 1,
+      max_node_count   = 4,
+      node_instance    = "Standard_E16s_v5"
+      cache            = "3"
       root_volume_size = 100
     },
     large = {
-      db             = "MO_Standard_E8ds_v4",
-      min_node_count = 1,
-      max_node_count = 4,
-      node_instance  = "Standard_E16s_v5"
-      cache          = "4"
+      db               = "MO_Standard_E8ds_v4",
+      min_node_count   = 1,
+      max_node_count   = 4,
+      node_instance    = "Standard_E16s_v5"
+      cache            = "4"
       root_volume_size = 256
     },
     xlarge = {
-      db             = "MO_Standard_E16ds_v4",
-      min_node_count = 1,
-      max_node_count = 4,
-      node_instance  = "Standard_E16s_v5"
-      cache          = "4"
+      db               = "MO_Standard_E16ds_v4",
+      min_node_count   = 1,
+      max_node_count   = 4,
+      node_instance    = "Standard_E16s_v5"
+      cache            = "4"
       root_volume_size = 256
     },
     xxlarge = {
-      db             = "MO_Standard_E32ds_v4",
-      min_node_count = 1,
-      max_node_count = 4,
-      node_instance  = "Standard_E16s_v5"
-      cache          = "5"
+      db               = "MO_Standard_E32ds_v4",
+      min_node_count   = 1,
+      max_node_count   = 4,
+      node_instance    = "Standard_E16s_v5"
+      cache            = "5"
       root_volume_size = 256
     }
   }

--- a/deployment-size.tf
+++ b/deployment-size.tf
@@ -2,11 +2,12 @@ locals {
   # Specifications for t-shirt sized deployments
   deployment_size = {
     small = {
-      db             = "MO_Standard_E2ds_v4",
-      min_node_count = 1,
-      max_node_count = 4,
-      node_instance  = "Standard_E8s_v5"
-      cache          = "3"
+      db               = "MO_Standard_E2ds_v4",
+      min_node_count   = 1,
+      max_node_count   = 4,
+      node_instance    = "Standard_E8s_v5"
+      cache            = "3"
+      root_volume_size = 100
     },
     medium = {
       db             = "MO_Standard_E4ds_v4",
@@ -14,6 +15,7 @@ locals {
       max_node_count = 4,
       node_instance  = "Standard_E16s_v5"
       cache          = "3"
+      root_volume_size = 100
     },
     large = {
       db             = "MO_Standard_E8ds_v4",
@@ -21,6 +23,7 @@ locals {
       max_node_count = 4,
       node_instance  = "Standard_E16s_v5"
       cache          = "4"
+      root_volume_size = 256
     },
     xlarge = {
       db             = "MO_Standard_E16ds_v4",
@@ -28,6 +31,7 @@ locals {
       max_node_count = 4,
       node_instance  = "Standard_E16s_v5"
       cache          = "4"
+      root_volume_size = 256
     },
     xxlarge = {
       db             = "MO_Standard_E32ds_v4",
@@ -35,6 +39,7 @@ locals {
       max_node_count = 4,
       node_instance  = "Standard_E16s_v5"
       cache          = "5"
+      root_volume_size = 256
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ locals {
   kubernetes_instance_type   = coalesce(var.kubernetes_instance_type, local.deployment_size[var.size].node_instance)
   kubernetes_min_node_per_az = coalesce(var.kubernetes_min_node_per_az, local.deployment_size[var.size].min_node_count)
   kubernetes_max_node_per_az = coalesce(var.kubernetes_max_node_per_az, local.deployment_size[var.size].max_node_count)
+  kubernetes_node_disk_size_gb = coalesce(var.kubernetes_node_disk_size_gb, local.deployment_size[var.size].root_volume_size)
 }
 
 resource "azurerm_resource_group" "default" {
@@ -155,6 +156,7 @@ module "app_aks" {
   node_pool_min_vm_per_az = local.kubernetes_min_node_per_az
   node_pool_max_vm_per_az = local.kubernetes_max_node_per_az
   node_pool_vm_size       = local.kubernetes_instance_type
+  node_pool_disk_size     = local.kubernetes_node_disk_size_gb
   node_pool_zones         = local.node_pool_zones
   public_subnet           = module.networking.public_subnet
   resource_group          = azurerm_resource_group.default

--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,11 @@ locals {
   url_prefix = var.ssl ? "https" : "http"
   url        = "${local.url_prefix}://${local.fqdn}"
 
-  redis_capacity             = coalesce(var.redis_capacity, local.deployment_size[var.size].cache)
-  database_sku_name          = coalesce(var.database_sku_name, local.deployment_size[var.size].db)
-  kubernetes_instance_type   = coalesce(var.kubernetes_instance_type, local.deployment_size[var.size].node_instance)
-  kubernetes_min_node_per_az = coalesce(var.kubernetes_min_node_per_az, local.deployment_size[var.size].min_node_count)
-  kubernetes_max_node_per_az = coalesce(var.kubernetes_max_node_per_az, local.deployment_size[var.size].max_node_count)
+  redis_capacity               = coalesce(var.redis_capacity, local.deployment_size[var.size].cache)
+  database_sku_name            = coalesce(var.database_sku_name, local.deployment_size[var.size].db)
+  kubernetes_instance_type     = coalesce(var.kubernetes_instance_type, local.deployment_size[var.size].node_instance)
+  kubernetes_min_node_per_az   = coalesce(var.kubernetes_min_node_per_az, local.deployment_size[var.size].min_node_count)
+  kubernetes_max_node_per_az   = coalesce(var.kubernetes_max_node_per_az, local.deployment_size[var.size].max_node_count)
   kubernetes_node_disk_size_gb = coalesce(var.kubernetes_node_disk_size_gb, local.deployment_size[var.size].root_volume_size)
 }
 
@@ -432,8 +432,8 @@ locals {
         }
 
         labels = var.create_private_link ? {
-            "sha_hash" = substr(sha256("yes"), 0, 50)
-          } : {}
+          "sha_hash" = substr(sha256("yes"), 0, 50)
+        } : {}
 
         tls = [
           { hosts = [trimprefix(trimprefix(local.url, "https://"), "http://")], secretName = "wandb-ssl-cert" }
@@ -443,7 +443,7 @@ locals {
           create       = var.create_private_link
           nameOverride = "${var.namespace}-private-ingress"
           annotations = {
-            "kubernetes.io/ingress.class"                   = "azure/application-gateway"
+            "kubernetes.io/ingress.class"                 = "azure/application-gateway"
             "appgw.ingress.kubernetes.io/request-timeout" = "300"
             "appgw.ingress.kubernetes.io/use-private-ip" : "true"
           }
@@ -452,7 +452,7 @@ locals {
           ]
         }
       }
- 
+
 
       otel = {
         daemonset = var.azuremonitor ? {

--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -24,6 +24,7 @@ resource "azurerm_kubernetes_cluster" "default" {
     max_pods                    = var.max_pods
     name                        = "default"
     node_count                  = var.node_pool_min_vm_per_az
+    os_disk_size_gb             = var.node_pool_disk_size
     max_count                   = var.node_pool_max_vm_per_az
     min_count                   = var.node_pool_min_vm_per_az
     temporary_name_for_rotation = "rotating"
@@ -66,6 +67,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "additional" {
   max_pods              = var.max_pods
   name                  = "zone${local.additonal_zones[count.index]}"
   node_count            = var.node_pool_min_vm_per_az
+  os_disk_size_gb       = var.node_pool_disk_size
   max_count             = var.node_pool_max_vm_per_az
   min_count             = var.node_pool_min_vm_per_az
   vm_size               = var.node_pool_vm_size

--- a/modules/app_aks/variables.tf
+++ b/modules/app_aks/variables.tf
@@ -54,6 +54,13 @@ variable "node_pool_max_vm_per_az" {
   type = number
 }
 
+variable "node_pool_disk_size" {
+  description = "The size of the OS disk volume in GiB for the root block device of node group instances."
+  nullable    = false
+  type        = number
+  default     = 100
+}
+
 variable "sku_tier" {
   type    = string
   default = "Free"

--- a/modules/app_lb/variables.tf
+++ b/modules/app_lb/variables.tf
@@ -34,7 +34,7 @@ variable "tags" {
 }
 
 variable "private_subnet" {
-  type        = object({ id = string })
+  type = object({ id = string })
 }
 
 variable "private_link" {

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_subnet" "kubernetes" {
 
   service_endpoints = concat(
     ["Microsoft.Sql", "Microsoft.KeyVault"],
-      var.private_link ? ["Microsoft.Storage.Global"] : ["Microsoft.Storage"]
+    var.private_link ? ["Microsoft.Storage.Global"] : ["Microsoft.Storage"]
   )
 }
 

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_redis_cache" "default" {
   sku_name            = var.sku_name
 
   access_keys_authentication_enabled = true
-  non_ssl_port_enabled = true
+  non_ssl_port_enabled               = true
 
   tags = var.tags
 

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -3,12 +3,12 @@ locals {
   truncated_namespace = substr(replace(var.namespace, "-", ""), 0, 24 - length(local.postfix))
 }
 resource "azurerm_storage_account" "default" {
-  name                     = "${local.truncated_namespace}${local.postfix}"
-  resource_group_name      = var.resource_group_name
-  location                 = var.location
-  account_tier             = "Standard"
-  account_replication_type = "ZRS"
-  min_tls_version          = "TLS1_2"
+  name                             = "${local.truncated_namespace}${local.postfix}"
+  resource_group_name              = var.resource_group_name
+  location                         = var.location
+  account_tier                     = "Standard"
+  account_replication_type         = "ZRS"
+  min_tls_version                  = "TLS1_2"
   cross_tenant_replication_enabled = true
 
   blob_properties {

--- a/variables.tf
+++ b/variables.tf
@@ -286,7 +286,7 @@ variable "kubernetes_max_node_per_az" {
 variable "kubernetes_node_disk_size_gb" {
   type        = number
   description = "Size of the node root volume in GB."
-  default     = "100"
+  default     = null
 }
 
 variable "kubernetes_cluster_tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -287,6 +287,12 @@ variable "kubernetes_max_node_per_az" {
   default     = null
 }
 
+variable "kubernetes_node_disk_size_gb" {
+  type        = number
+  description = "Size of the node root volume in GB."
+  default     = "100"
+}
+
 variable "kubernetes_cluster_tags" {
   description = "A map of tags to apply to all resources managed by the AKS cluster"
   type        = map(string)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support to configure Kubernetes node OS disk size across all node pools. Defaults now vary by deployment size (small/medium: 128 GB; large/xlarge/xxlarge: 256 GB) with an option to override via a new input for custom sizing.

- Documentation
  - Updated README Inputs to document the new disk size setting, including type, default, and description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->