### PR TITLE
Add CSI driver support for internal service authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ resources that lack official modules.
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | ~> 1.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.26 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.6 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 1.19 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.23 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
@@ -119,6 +120,7 @@ resources that lack official modules.
 | <a name="input_external_redis_host"></a> [external\_redis\_host](#input\_external\_redis\_host) | host for the redis instance created externally | `string` | `null` | no |
 | <a name="input_external_redis_params"></a> [external\_redis\_params](#input\_external\_redis\_params) | queryVar params for redis instance created externally | `object({})` | `null` | no |
 | <a name="input_external_redis_port"></a> [external\_redis\_port](#input\_external\_redis\_port) | port for the redis instance created externally | `string` | `null` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The Kubernetes namespace where W&B resources will be deployed | `string` | `"default"` | no |
 | <a name="input_kubernetes_cluster_tags"></a> [kubernetes\_cluster\_tags](#input\_kubernetes\_cluster\_tags) | A map of tags to apply to all resources managed by the AKS cluster | `map(string)` | `{}` | no |
 | <a name="input_kubernetes_instance_type"></a> [kubernetes\_instance\_type](#input\_kubernetes\_instance\_type) | Instance type for primary node group. Defaults to null and value from deployment-size.tf is used | `string` | `null` | no |
 | <a name="input_kubernetes_max_node_per_az"></a> [kubernetes\_max\_node\_per\_az](#input\_kubernetes\_max\_node\_per\_az) | Maximum number of nodes for the AKS cluster. Defaults to null and value from deployment-size.tf is used | `number` | `null` | no |
@@ -138,6 +140,8 @@ resources that lack official modules.
 | <a name="input_other_wandb_env"></a> [other\_wandb\_env](#input\_other\_wandb\_env) | Extra environment variables for W&B | `map(any)` | `{}` | no |
 | <a name="input_parquet_wandb_env"></a> [parquet\_wandb\_env](#input\_parquet\_wandb\_env) | Extra environment variables for W&B | `map(string)` | `{}` | no |
 | <a name="input_redis_capacity"></a> [redis\_capacity](#input\_redis\_capacity) | Number indicating size of an redis instance. Defaults to null and value from deployment-size.tf is used | `number` | `null` | no |
+| <a name="input_secrets_store_csi_driver_provider_azure_version"></a> [secrets\_store\_csi\_driver\_provider\_azure\_version](#input\_secrets\_store\_csi\_driver\_provider\_azure\_version) | The version of the Azure Key Vault Provider for Secrets Store CSI Driver to install | `string` | `"1.7.1"` | no |
+| <a name="input_secrets_store_csi_driver_version"></a> [secrets\_store\_csi\_driver\_version](#input\_secrets\_store\_csi\_driver\_version) | The version of the Secrets Store CSI Driver Helm chart to install | `string` | `"1.4.7"` | no |
 | <a name="input_size"></a> [size](#input\_size) | Deployment size | `string` | `"small"` | no |
 | <a name="input_ssl"></a> [ssl](#input\_ssl) | Enable SSL certificate | `bool` | `true` | no |
 | <a name="input_storage_account"></a> [storage\_account](#input\_storage\_account) | Azure storage account name | `string` | `""` | no |
@@ -172,6 +176,7 @@ resources that lack official modules.
 | <a name="output_private_link_resource_id"></a> [private\_link\_resource\_id](#output\_private\_link\_resource\_id) | n/a |
 | <a name="output_private_link_sub_resource_name"></a> [private\_link\_sub\_resource\_name](#output\_private\_link\_sub\_resource\_name) | n/a |
 | <a name="output_standardized_size"></a> [standardized\_size](#output\_standardized\_size) | n/a |
+| <a name="output_storage_account_name"></a> [storage\_account\_name](#output\_storage\_account\_name) | Name of the storage account |
 | <a name="output_tenant_id"></a> [tenant\_id](#output\_tenant\_id) | n/a |
 | <a name="output_url"></a> [url](#output\_url) | The URL to the W&B application |
 | <a name="output_wandb_spec"></a> [wandb\_spec](#output\_wandb\_spec) | n/a |

--- a/main.tf
+++ b/main.tf
@@ -151,6 +151,8 @@ module "app_aks" {
   etcd_key_vault_key_id   = module.vault.etcd_key_id
   gateway                 = module.app_lb.gateway
   identity                = module.identity.identity
+  k8s_namespace           = var.wandb_namespace
+  key_vault_id            = module.vault.vault_id
   location                = azurerm_resource_group.default.location
   namespace               = var.namespace
   node_pool_min_vm_per_az = local.kubernetes_min_node_per_az
@@ -306,6 +308,10 @@ locals {
 
   bucket_config                    = var.external_bucket != null ? var.external_bucket : (local.use_customer_bucket ? local.default_bucket_config : null)
   weave_trace_service_account_name = "wandb-weave-trace"
+
+  weave_worker_workload_identity_annotations = {
+    "azure.workload.identity/client-id" = module.app_aks.weave_worker_identity_client_id
+  }
 
   ctrlplane_redis_host = "redis.redis.svc.cluster.local"
   ctrlplane_redis_port = "26379"
@@ -556,6 +562,37 @@ locals {
         }
         podLabels = { "azure.workload.identity/use" = "true" }
         extraEnv  = var.parquet_wandb_env
+      }
+
+      weave-trace-worker = {
+        serviceAccount = {
+          annotations = local.weave_worker_workload_identity_annotations
+          labels      = { "azure.workload.identity/use" = "true" }
+        }
+        pod = {
+          labels = { "azure.workload.identity/use" = "true" }
+        }
+        podLabels = { "azure.workload.identity/use" = "true" }
+        secretsStore = {
+          enabled = true
+        }
+      }
+
+      secretsStore = {
+        enabled  = true
+        provider = "azure"
+        azure = {
+          keyVaultName = module.vault.vault.name
+          tenantId     = module.app_aks.tenant_id
+        }
+        secrets = [
+          {
+            name            = "weave-worker-auth"
+            cloudSecretName = module.vault.weave_worker_auth_secret_name
+            k8sSecretName   = "weave-worker-auth"
+            k8sSecretKey    = "key"
+          }
+        ]
       }
 
       executor = {

--- a/main.tf
+++ b/main.tf
@@ -151,7 +151,7 @@ module "app_aks" {
   etcd_key_vault_key_id   = module.vault.etcd_key_id
   gateway                 = module.app_lb.gateway
   identity                = module.identity.identity
-  k8s_namespace           = var.wandb_namespace
+  k8s_namespace           = var.k8s_namespace
   key_vault_id            = module.vault.vault_id
   location                = azurerm_resource_group.default.location
   namespace               = var.namespace

--- a/main.tf
+++ b/main.tf
@@ -143,9 +143,10 @@ locals {
   node_pool_zones  = var.node_pool_zones != null ? var.node_pool_zones : slice(sort(local.valid_zones), 0, local.num_zones)
 }
 
-# Fetch Azure provider manifest at root level to ensure early evaluation in Terraform Cloud
-data "http" "azure_provider_manifest" {
-  url = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/v${var.secrets_store_csi_driver_provider_azure_version}/deployment/provider-azure-installer.yaml"
+# Use vendored Azure provider manifest for reliability and consistency
+locals {
+  azure_provider_manifest_path = "${path.module}/modules/app_aks/secrets_store/manifests/azure-provider-installer-v${var.secrets_store_csi_driver_provider_azure_version}.yaml"
+  azure_provider_manifest_body = file(local.azure_provider_manifest_path)
 }
 
 module "app_aks" {
@@ -170,7 +171,7 @@ module "app_aks" {
   sku_tier                                        = var.cluster_sku_tier
   tags                                            = merge(var.tags, var.kubernetes_cluster_tags)
   secrets_store_csi_driver_version                = var.secrets_store_csi_driver_version
-  azure_provider_manifest_body                    = data.http.azure_provider_manifest.response_body
+  azure_provider_manifest_body                    = local.azure_provider_manifest_body
 }
 locals {
   service_account_name         = "wandb-app"

--- a/main.tf
+++ b/main.tf
@@ -143,27 +143,34 @@ locals {
   node_pool_zones  = var.node_pool_zones != null ? var.node_pool_zones : slice(sort(local.valid_zones), 0, local.num_zones)
 }
 
+# Fetch Azure provider manifest at root level to ensure early evaluation in Terraform Cloud
+data "http" "azure_provider_manifest" {
+  url = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/v${var.secrets_store_csi_driver_provider_azure_version}/deployment/provider-azure-installer.yaml"
+}
+
 module "app_aks" {
   source     = "./modules/app_aks"
   depends_on = [module.app_lb]
 
-  cluster_subnet_id       = module.networking.kubernetes_subnet.id
-  etcd_key_vault_key_id   = module.vault.etcd_key_id
-  gateway                 = module.app_lb.gateway
-  identity                = module.identity.identity
-  k8s_namespace           = var.k8s_namespace
-  key_vault_id            = module.vault.vault_id
-  location                = azurerm_resource_group.default.location
-  namespace               = var.namespace
-  node_pool_min_vm_per_az = local.kubernetes_min_node_per_az
-  node_pool_max_vm_per_az = local.kubernetes_max_node_per_az
-  node_pool_vm_size       = local.kubernetes_instance_type
-  node_pool_disk_size     = local.kubernetes_node_disk_size_gb
-  node_pool_zones         = local.node_pool_zones
-  public_subnet           = module.networking.public_subnet
-  resource_group          = azurerm_resource_group.default
-  sku_tier                = var.cluster_sku_tier
-  tags                    = merge(var.tags, var.kubernetes_cluster_tags)
+  cluster_subnet_id                               = module.networking.kubernetes_subnet.id
+  etcd_key_vault_key_id                           = module.vault.etcd_key_id
+  gateway                                         = module.app_lb.gateway
+  identity                                        = module.identity.identity
+  k8s_namespace                                   = var.k8s_namespace
+  key_vault_id                                    = module.vault.vault_id
+  location                                        = azurerm_resource_group.default.location
+  namespace                                       = var.namespace
+  node_pool_min_vm_per_az                         = local.kubernetes_min_node_per_az
+  node_pool_max_vm_per_az                         = local.kubernetes_max_node_per_az
+  node_pool_vm_size                               = local.kubernetes_instance_type
+  node_pool_disk_size                             = local.kubernetes_node_disk_size_gb
+  node_pool_zones                                 = local.node_pool_zones
+  public_subnet                                   = module.networking.public_subnet
+  resource_group                                  = azurerm_resource_group.default
+  sku_tier                                        = var.cluster_sku_tier
+  tags                                            = merge(var.tags, var.kubernetes_cluster_tags)
+  secrets_store_csi_driver_version                = var.secrets_store_csi_driver_version
+  azure_provider_manifest_body                    = data.http.azure_provider_manifest.response_body
 }
 locals {
   service_account_name         = "wandb-app"

--- a/main.tf
+++ b/main.tf
@@ -591,6 +591,7 @@ locals {
         azure = {
           keyVaultName = module.vault.vault.name
           tenantId     = module.app_aks.tenant_id
+          clientID     = module.app_aks.weave_worker_identity_client_id
         }
         secrets = [
           {

--- a/main.tf
+++ b/main.tf
@@ -591,7 +591,7 @@ locals {
         azure = {
           keyVaultName = module.vault.vault.name
           tenantId     = module.app_aks.tenant_id
-          clientID     = module.app_aks.weave_worker_identity_client_id
+          # clientID is NOT included - workload identity uses the pod's service account token
         }
         secrets = [
           {

--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -106,3 +106,54 @@ resource "azurerm_role_assignment" "public_subnet" {
   role_definition_name = "Contributor"
   principal_id         = local.ingress_gateway_principal_id
 }
+
+# Install Secrets Store CSI Driver and Azure Key Vault Provider
+module "secrets_store" {
+  source = "./secrets_store"
+
+  secrets_store_csi_driver_version                = var.secrets_store_csi_driver_version
+  secrets_store_csi_driver_provider_azure_version = var.secrets_store_csi_driver_provider_azure_version
+
+  depends_on = [
+    azurerm_kubernetes_cluster.default,
+    azurerm_kubernetes_cluster_node_pool.additional
+  ]
+}
+
+# Get current Azure client configuration
+data "azurerm_client_config" "current" {}
+
+# Create Azure Managed Identity for weave workers to access Key Vault
+resource "azurerm_user_assigned_identity" "weave_worker" {
+  name                = "${var.namespace}-weave-wkr"
+  location            = var.location
+  resource_group_name = var.resource_group.name
+
+  tags = var.tags
+}
+
+# Grant the weave worker managed identity access to read secrets from Key Vault
+resource "azurerm_key_vault_access_policy" "weave_worker" {
+  key_vault_id = var.key_vault_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = azurerm_user_assigned_identity.weave_worker.principal_id
+
+  secret_permissions = ["Get"]
+
+  depends_on = [
+    azurerm_user_assigned_identity.weave_worker
+  ]
+}
+
+# Workload Identity binding - allows weave-trace-worker K8s service account to impersonate Azure managed identity
+resource "azurerm_federated_identity_credential" "weave_trace_worker" {
+  name                = "${var.namespace}-weave-trace-worker-federated"
+  resource_group_name = var.resource_group.name
+  parent_id           = azurerm_user_assigned_identity.weave_worker.id
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = azurerm_kubernetes_cluster.default.oidc_issuer_url
+  subject             = "system:serviceaccount:${var.k8s_namespace}:wandb-weave-trace-worker"
+}
+
+# NOTE: The Kubernetes secrets are now created by the Secrets Store CSI Driver
+# via the SecretProviderClass defined in the operator-wandb Helm chart.

--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -107,17 +107,13 @@ resource "azurerm_role_assignment" "public_subnet" {
   principal_id         = local.ingress_gateway_principal_id
 }
 
-# Fetch Azure provider manifest early to avoid for_each issues in Terraform Cloud
-data "http" "azure_provider_manifest" {
-  url = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/v${var.secrets_store_csi_driver_provider_azure_version}/deployment/provider-azure-installer.yaml"
-}
-
 # Install Secrets Store CSI Driver and Azure Key Vault Provider
+# Note: azure_provider_manifest_body is fetched at root module level
 module "secrets_store" {
   source = "./secrets_store"
 
   secrets_store_csi_driver_version = var.secrets_store_csi_driver_version
-  azure_provider_manifest_body     = data.http.azure_provider_manifest.response_body
+  azure_provider_manifest_body     = var.azure_provider_manifest_body
 
   depends_on = [
     azurerm_kubernetes_cluster.default,

--- a/modules/app_aks/main.tf
+++ b/modules/app_aks/main.tf
@@ -107,12 +107,17 @@ resource "azurerm_role_assignment" "public_subnet" {
   principal_id         = local.ingress_gateway_principal_id
 }
 
+# Fetch Azure provider manifest early to avoid for_each issues in Terraform Cloud
+data "http" "azure_provider_manifest" {
+  url = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/v${var.secrets_store_csi_driver_provider_azure_version}/deployment/provider-azure-installer.yaml"
+}
+
 # Install Secrets Store CSI Driver and Azure Key Vault Provider
 module "secrets_store" {
   source = "./secrets_store"
 
-  secrets_store_csi_driver_version                = var.secrets_store_csi_driver_version
-  secrets_store_csi_driver_provider_azure_version = var.secrets_store_csi_driver_provider_azure_version
+  secrets_store_csi_driver_version = var.secrets_store_csi_driver_version
+  azure_provider_manifest_body     = data.http.azure_provider_manifest.response_body
 
   depends_on = [
     azurerm_kubernetes_cluster.default,

--- a/modules/app_aks/outputs.tf
+++ b/modules/app_aks/outputs.tf
@@ -22,3 +22,18 @@ output "cluster_ca_certificate" {
 output "oidc_issuer_url" {
   value = azurerm_kubernetes_cluster.default.oidc_issuer_url
 }
+
+output "weave_worker_identity_client_id" {
+  value       = azurerm_user_assigned_identity.weave_worker.client_id
+  description = "The client ID of the managed identity used by weave workers for Key Vault access"
+}
+
+output "weave_worker_identity_principal_id" {
+  value       = azurerm_user_assigned_identity.weave_worker.principal_id
+  description = "The principal ID (object ID) of the managed identity used by weave workers"
+}
+
+output "tenant_id" {
+  value       = data.azurerm_client_config.current.tenant_id
+  description = "The Azure tenant ID"
+}

--- a/modules/app_aks/secrets_store/manifests/azure-provider-installer-v1.7.1.yaml
+++ b/modules/app_aks/secrets_store/manifests/azure-provider-installer-v1.7.1.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-azure
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: csi-secrets-store-provider-azure
+  name: csi-secrets-store-provider-azure
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-azure
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-azure
+    spec:
+      serviceAccountName: csi-secrets-store-provider-azure
+      hostNetwork: true
+      containers:
+        - name: provider-azure-installer
+          image: mcr.microsoft.com/oss/v2/azure/secrets-store/provider-azure:v1.7.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=unix:///provider/azure.sock
+            - --construct-pem-chain=true
+            - --healthz-port=8989
+            - --healthz-path=/healthz
+            - --healthz-timeout=5s
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8989
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          ports:
+            - containerPort: 8898
+              name: metrics
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+            capabilities:
+              drop:
+              - ALL
+          volumeMounts:
+            - mountPath: "/provider"
+              name: providervol
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "/var/run/secrets-store-csi-providers"
+      tolerations:
+      - operator: Exists
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/modules/app_aks/secrets_store/secrets_store.tf
+++ b/modules/app_aks/secrets_store/secrets_store.tf
@@ -29,13 +29,9 @@ resource "helm_release" "secrets_store_csi_driver" {
 
 # Install Azure Key Vault Provider for Secrets Store CSI Driver
 # NOTE: Manifest is fetched at parent level to ensure early evaluation in Terraform Cloud
-data "http" "azure_provider_manifest" {
-  url = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/v${var.secrets_store_csi_driver_provider_azure_version}/deployment/provider-azure-installer.yaml"
-}
-
 locals {
   azure_provider_manifests = [
-    for manifest in split("---", data.http.azure_provider_manifest.response_body) :
+    for manifest in split("---", var.azure_provider_manifest_body) :
     manifest
     if trimspace(manifest) != "" && can(yamldecode(manifest))
   ]

--- a/modules/app_aks/secrets_store/secrets_store.tf
+++ b/modules/app_aks/secrets_store/secrets_store.tf
@@ -1,0 +1,59 @@
+# Install Secrets Store CSI Driver via Helm
+resource "helm_release" "secrets_store_csi_driver" {
+  name       = "secrets-store-csi-driver"
+  repository = "https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts"
+  chart      = "secrets-store-csi-driver"
+  version    = var.secrets_store_csi_driver_version
+  namespace  = "kube-system"
+
+  set {
+    name  = "syncSecret.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "enableSecretRotation"
+    value = "true"
+  }
+
+  set {
+    name  = "rotationPollInterval"
+    value = "120s"
+  }
+
+  set {
+    name  = "tokenRequests[0].audience"
+    value = "api://AzureADTokenExchange"
+  }
+}
+
+# Install Azure Key Vault Provider for Secrets Store CSI Driver
+# NOTE: Manifest is fetched at parent level to ensure early evaluation in Terraform Cloud
+data "http" "azure_provider_manifest" {
+  url = "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/v${var.secrets_store_csi_driver_provider_azure_version}/deployment/provider-azure-installer.yaml"
+}
+
+locals {
+  azure_provider_manifests = [
+    for manifest in split("---", data.http.azure_provider_manifest.response_body) :
+    manifest
+    if trimspace(manifest) != "" && can(yamldecode(manifest))
+  ]
+}
+
+resource "kubectl_manifest" "azure_provider" {
+  for_each = { for idx, manifest in local.azure_provider_manifests : idx => manifest }
+
+  yaml_body = each.value
+
+  server_side_apply = true
+  wait              = true
+
+  depends_on = [
+    helm_release.secrets_store_csi_driver
+  ]
+}
+
+# NOTE: The SecretProviderClass is created by the application Helm chart (operator-wandb),
+# not by Terraform. This avoids CRD timing issues and keeps application-specific configuration
+# with the application deployment.

--- a/modules/app_aks/secrets_store/variables.tf
+++ b/modules/app_aks/secrets_store/variables.tf
@@ -1,0 +1,9 @@
+variable "secrets_store_csi_driver_version" {
+  type        = string
+  description = "The version of the Secrets Store CSI Driver Helm chart to install"
+}
+
+variable "secrets_store_csi_driver_provider_azure_version" {
+  type        = string
+  description = "The version of the Azure Key Vault Provider for Secrets Store CSI Driver to install"
+}

--- a/modules/app_aks/secrets_store/variables.tf
+++ b/modules/app_aks/secrets_store/variables.tf
@@ -3,7 +3,7 @@ variable "secrets_store_csi_driver_version" {
   description = "The version of the Secrets Store CSI Driver Helm chart to install"
 }
 
-variable "secrets_store_csi_driver_provider_azure_version" {
+variable "azure_provider_manifest_body" {
   type        = string
-  description = "The version of the Azure Key Vault Provider for Secrets Store CSI Driver to install"
+  description = "The raw YAML content of the Azure Key Vault Provider manifest"
 }

--- a/modules/app_aks/secrets_store/versions.tf
+++ b/modules/app_aks/secrets_store/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.19.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.10"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/modules/app_aks/secrets_store/versions.tf
+++ b/modules/app_aks/secrets_store/versions.tf
@@ -8,9 +8,5 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 2.10"
     }
-    http = {
-      source  = "hashicorp/http"
-      version = ">= 3.0"
-    }
   }
 }

--- a/modules/app_aks/variables.tf
+++ b/modules/app_aks/variables.tf
@@ -95,12 +95,6 @@ variable "secrets_store_csi_driver_version" {
   default     = "1.4.7"
 }
 
-variable "secrets_store_csi_driver_provider_azure_version" {
-  type        = string
-  description = "The version of the Azure Key Vault Provider for Secrets Store CSI Driver to install"
-  default     = "1.7.1"
-}
-
 variable "azure_provider_manifest_body" {
   type        = string
   description = "The raw YAML content of the Azure Key Vault Provider manifest, fetched at root module level"

--- a/modules/app_aks/variables.tf
+++ b/modules/app_aks/variables.tf
@@ -100,3 +100,8 @@ variable "secrets_store_csi_driver_provider_azure_version" {
   description = "The version of the Azure Key Vault Provider for Secrets Store CSI Driver to install"
   default     = "1.7.1"
 }
+
+variable "azure_provider_manifest_body" {
+  type        = string
+  description = "The raw YAML content of the Azure Key Vault Provider manifest, fetched at root module level"
+}

--- a/modules/app_aks/variables.tf
+++ b/modules/app_aks/variables.tf
@@ -77,3 +77,26 @@ variable "node_pool_zones" {
   description = "Availability zones for the node pool"
   default     = ["1", "2"]
 }
+
+variable "key_vault_id" {
+  type        = string
+  description = "The ID of the Azure Key Vault to grant CSI driver access to"
+}
+
+variable "k8s_namespace" {
+  type        = string
+  description = "The Kubernetes namespace where W&B resources will be deployed"
+  default     = "default"
+}
+
+variable "secrets_store_csi_driver_version" {
+  type        = string
+  description = "The version of the Secrets Store CSI Driver Helm chart to install"
+  default     = "1.4.7"
+}
+
+variable "secrets_store_csi_driver_provider_azure_version" {
+  type        = string
+  description = "The version of the Azure Key Vault Provider for Secrets Store CSI Driver to install"
+  default     = "1.7.1"
+}

--- a/modules/app_aks/versions.tf
+++ b/modules/app_aks/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.19.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.10"
+    }
+  }
+}

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -9,10 +9,3 @@ output "container" {
 output "queue" {
   value = var.create_queue ? module.queue.0.queue : null
 }
-
-# TODO(aravind): Remove - for testing bufstream
-output "primary_access_key" {
-  value       = azurerm_storage_account.default.primary_access_key
-  sensitive   = true
-  description = "Primary access key for storage account"
-}

--- a/modules/storage/outputs.tf
+++ b/modules/storage/outputs.tf
@@ -9,3 +9,10 @@ output "container" {
 output "queue" {
   value = var.create_queue ? module.queue.0.queue : null
 }
+
+# TODO(aravind): Remove - for testing bufstream
+output "primary_access_key" {
+  value       = azurerm_storage_account.default.primary_access_key
+  sensitive   = true
+  description = "Primary access key for storage account"
+}

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -2,7 +2,8 @@
 data "azurerm_client_config" "current" {}
 
 locals {
-  vault_name           = "${var.namespace}-vault"
+  # TODO(aravind): Remove the -v2 suffix after purging the old soft-deleted vault
+  vault_name           = "${var.namespace}-vault-v2"
   vault_truncated_name = substr(local.vault_name, 0, min(length(local.vault_name), 24))
   max_key_length       = 127
   vault_key_map = {

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -2,9 +2,7 @@
 data "azurerm_client_config" "current" {}
 
 locals {
-  # TODO(aravind): Remove the -v2 suffix after purging the old soft-deleted vault
-  namespace_truncated  = substr(var.namespace, 0, min(length(var.namespace), 13))
-  vault_name           = "${local.namespace_truncated}-vault-v2"
+  vault_name           = "${var.namespace}-vault"
   vault_truncated_name = substr(local.vault_name, 0, min(length(local.vault_name), 24))
   max_key_length       = 127
   vault_key_map = {

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -87,16 +87,11 @@ resource "azurerm_key_vault_secret" "weave_worker_auth" {
   name         = "weave-worker-auth"
   value        = random_password.weave_worker_auth.result
   key_vault_id = azurerm_key_vault.default.id
+
+  depends_on = [azurerm_key_vault_access_policy.parent, azurerm_key_vault_access_policy.identity]
 }
 
-resource "kubernetes_secret" "weave_worker_auth" {
-  metadata {
-    name = "weave-worker-auth"
-  }
-
-  data = {
-    key = random_password.weave_worker_auth.result
-  }
-
-  type = "Opaque"
-}
+# NOTE: The Kubernetes secrets are now created by the Secrets Store CSI Driver
+# via the SecretProviderClass defined in the operator-wandb Helm chart.
+# This eliminates the need to manage secrets in both Terraform and Kubernetes,
+# and provides automatic secret rotation capabilities.

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -3,7 +3,8 @@ data "azurerm_client_config" "current" {}
 
 locals {
   # TODO(aravind): Remove the -v2 suffix after purging the old soft-deleted vault
-  vault_name           = "${var.namespace}-vault-v2"
+  namespace_truncated  = substr(var.namespace, 0, min(length(var.namespace), 13))
+  vault_name           = "${local.namespace_truncated}-vault-v2"
   vault_truncated_name = substr(local.vault_name, 0, min(length(local.vault_name), 24))
   max_key_length       = 127
   vault_key_map = {

--- a/modules/vault/outputs.tf
+++ b/modules/vault/outputs.tf
@@ -17,3 +17,8 @@ output "vault_internal_keys" {
 output "vault_key_map" {
   value = local.vault_key_map
 }
+
+output "weave_worker_auth_secret_name" {
+  value       = azurerm_key_vault_secret.weave_worker_auth.name
+  description = "The name of the weave worker authentication secret in Azure Key Vault"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -73,3 +73,9 @@ output "wandb_spec" {
   value     = local.spec
   sensitive = true
 }
+
+# TODO(aravind): Remove - for testing bufstream
+output "storage_account_name" {
+  value       = module.storage[0].account.name
+  description = "Name of the storage account"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -73,3 +73,15 @@ output "wandb_spec" {
   value     = local.spec
   sensitive = true
 }
+
+# TODO(aravind): Remove - for testing bufstream
+output "storage_account_name" {
+  value       = module.storage[0].account.name
+  description = "Name of the storage account"
+}
+
+output "storage_account_primary_access_key" {
+  value       = module.storage[0].primary_access_key
+  sensitive   = true
+  description = "Primary access key for storage account"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -73,15 +73,3 @@ output "wandb_spec" {
   value     = local.spec
   sensitive = true
 }
-
-# TODO(aravind): Remove - for testing bufstream
-output "storage_account_name" {
-  value       = module.storage[0].account.name
-  description = "Name of the storage account"
-}
-
-output "storage_account_primary_access_key" {
-  value       = module.storage[0].primary_access_key
-  sensitive   = true
-  description = "Primary access key for storage account"
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -74,14 +74,7 @@ output "wandb_spec" {
   sensitive = true
 }
 
-# TODO(aravind): Remove - for testing bufstream
 output "storage_account_name" {
   value       = module.storage[0].account.name
   description = "Name of the storage account"
-}
-
-output "storage_account_primary_access_key" {
-  value       = module.storage[0].primary_access_key
-  sensitive   = true
-  description = "Primary access key for storage account"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -79,3 +79,9 @@ output "storage_account_name" {
   value       = module.storage[0].account.name
   description = "Name of the storage account"
 }
+
+output "storage_account_primary_access_key" {
+  value       = module.storage[0].primary_access_key
+  sensitive   = true
+  description = "Primary access key for storage account"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -404,3 +404,9 @@ variable "clickhouse_region" {
   description = "ClickHouse region (eastus2, westus3, etc)."
   default     = ""
 }
+
+variable "k8s_namespace" {
+  type        = string
+  description = "The Kubernetes namespace where W&B resources will be deployed"
+  default     = "default"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -410,3 +410,18 @@ variable "k8s_namespace" {
   description = "The Kubernetes namespace where W&B resources will be deployed"
   default     = "default"
 }
+
+###########################################
+# Secrets Store CSI Driver                #
+###########################################
+variable "secrets_store_csi_driver_version" {
+  type        = string
+  description = "The version of the Secrets Store CSI Driver Helm chart to install"
+  default     = "1.4.7"
+}
+
+variable "secrets_store_csi_driver_provider_azure_version" {
+  type        = string
+  description = "The version of the Azure Key Vault Provider for Secrets Store CSI Driver to install"
+  default     = "1.7.1"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -21,10 +21,6 @@ terraform {
       source  = "gavinbunney/kubectl"
       version = "~> 1.19"
     }
-    http = {
-      source  = "hashicorp/http"
-      version = "~> 3.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = "~> 3.0"

--- a/versions.tf
+++ b/versions.tf
@@ -17,6 +17,14 @@ terraform {
       source  = "hashicorp/helm"
       version = "~> 2.6"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.19"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.0"
+    }
     null = {
       source  = "hashicorp/null"
       version = "~> 3.0"


### PR DESCRIPTION
Implements Secrets Store CSI Driver integration for Azure to enable secure, dynamic secret mounting from Azure Key Vault into Kubernetes.

Changes:
- Install Secrets Store CSI Driver (v1.4.7) and Azure provider (v1.7.1) via Helm/kubectl manifest in kube-system namespace
- Create weave_worker managed identity with Workload Identity
- Configure Key Vault access policies for read-only secret access
- Generate random weave worker auth token and store in Azure Key Vault
- Add Helm chart configuration for weave-trace-worker with CSI driver support
- Remove kubernetes_secret resource (now synced via CSI driver)
- Add kubectl and http provider requirements

The CSI driver automatically syncs secrets from Azure Key Vault to Kubernetes, enabling secret rotation and eliminating the need to manage secrets in both places. SecretProviderClass resources are created by the operator-wandb Helm chart.

This provides the infrastructure for internal service authentication where services authenticate via Kubernetes secrets that are dynamically mounted from cloud secrets managers.

https://wandb.atlassian.net/browse/WB-28631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure Key Vault integration via the Secrets Store CSI Driver for secure secret delivery.
  * Workload identity support enabling managed identity binding for workloads.
  * Configurable Kubernetes namespace and CSI/provider driver versions.
  * Installer and deployment of the Azure Key Vault provider to the cluster.

* **Chores**
  * Added provider requirements for kubectl and HTTP.
  * Moved Kubernetes secret management to the CSI Driver.
  * Added outputs exposing storage account name and identity/tenant info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->