### PR TITLE
chore(backend): Use Azure default sort_buffer_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ resources that lack official modules.
 | <a name="input_database_availability_mode"></a> [database\_availability\_mode](#input\_database\_availability\_mode) | n/a | `string` | `"SameZone"` | no |
 | <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | MySQL server parameters to set on the Azure Database for MySQL flexible server. Merged with W&B defaults. | `map(string)` | `{}` | no |
 | <a name="input_database_sku_name"></a> [database\_sku\_name](#input\_database\_sku\_name) | Specifies the SKU Name for this MySQL Server. Defaults to null and value from deployment-size.tf is used | `string` | `null` | no |
-| <a name="input_database_sort_buffer_size"></a> [database\_sort\_buffer\_size](#input\_database\_sort\_buffer\_size) | Specifies the sort\_buffer\_size value to set for the database | `number` | `67108864` | no |
+| <a name="input_database_sort_buffer_size"></a> [database\_sort\_buffer\_size](#input\_database\_sort\_buffer\_size) | Specifies the sort\_buffer\_size value to set for the database | `number` | `524288` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | Version for MySQL | `string` | `"5.7"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | If the instance should have deletion protection enabled. The database / Bucket can't be deleted when this value is set to `true`. | `bool` | `true` | no |
 | <a name="input_disable_storage_vault_key_id"></a> [disable\_storage\_vault\_key\_id](#input\_disable\_storage\_vault\_key\_id) | Flag to disable the `customer_managed_key` block, the properties 'encryption.identity, encryption.keyvaultproperties' cannot be updated in a single operation. | `bool` | `false` | no |

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -24,7 +24,7 @@ locals {
     "max_binlog_size"            = "1073741824"
     "long_query_time"            = "4"
     "max_prepared_stmt_count"    = "65528"
-    "max_execution_time"         = "60000"
+    "max_execution_time"         = "600000"
     "slow_query_log"             = "on"
     "sort_buffer_size"           = tostring(var.sort_buffer_size)
   }

--- a/variables.tf
+++ b/variables.tf
@@ -178,7 +178,7 @@ variable "database_flags" {
 variable "database_sort_buffer_size" {
   description = "Specifies the sort_buffer_size value to set for the database"
   type        = number
-  default     = 67108864
+  default     = 524288
 }
 
 ##########################################


### PR DESCRIPTION
Use Azure's default sort_buffer_size.
* Commit d0e3439768079118ebcc863ac46471521ba21c48 was lost in #161 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default database sort buffer size from 67108864 to 524288.
  * Increased default database max execution time from 60000 to 600000.

* **Documentation**
  * Updated module documentation to reflect the revised default configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->