### PR TITLE
chore(backend): Remove max_prepared_stmt_count

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -38,7 +38,6 @@ locals {
     "binlog_row_image"           = "minimal"
     "max_binlog_size"            = "1073741824"
     "long_query_time"            = "4"
-    "max_prepared_stmt_count"    = "65528"
     "max_execution_time"         = "600000"
     "slow_query_log"             = "on"
     "sort_buffer_size"           = tostring(var.sort_buffer_size)


### PR DESCRIPTION
Reverting module default to match Azure default for max_prepared_stmt_count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the maximum prepared statement count configuration setting from MySQL database default configuration to resolve potential compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->