### PR TITLE
chore(terraform): Add wandb-weave-trace-worker SA to internalJWTMap

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -306,8 +306,9 @@ locals {
     accessKey = var.storage_key
   }
 
-  bucket_config                    = var.external_bucket != null ? var.external_bucket : (local.use_customer_bucket ? local.default_bucket_config : null)
-  weave_trace_service_account_name = "wandb-weave-trace"
+  bucket_config                           = var.external_bucket != null ? var.external_bucket : (local.use_customer_bucket ? local.default_bucket_config : null)
+  weave_trace_service_account_name        = "wandb-weave-trace"
+  weave_trace_worker_service_account_name = "wandb-weave-trace-worker"
 
   ctrlplane_redis_host = "redis.redis.svc.cluster.local"
   ctrlplane_redis_port = "26379"
@@ -406,7 +407,11 @@ locals {
           {
             subject = "system:serviceaccount:default:${local.weave_trace_service_account_name}",
             issuer  = module.app_aks.oidc_issuer_url
-          }
+          },
+          {
+            subject = "system:serviceaccount:default:${local.weave_trace_worker_service_account_name}",
+            issuer  = module.app_aks.oidc_issuer_url
+          },
         ]
       }
 


### PR DESCRIPTION
## Summary
- Add the `wandb-weave-trace-worker` service account to `app.internalJWTMap` on the WeightsAndBiases CR rendered by this module.
- Reason: Helm replaces lists wholesale, so the per-cluster override silently clobbers the chart-default two-entry list in `operator-wandb`. Every managed install ends up with only `wandb-weave-trace` registered, and worker calls to `/service-dangerzone/secrets/...` get 401 from gorilla's JWT middleware (`sub` not found in `GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS`).
- Audit across the fleet: **110 / 110** reachable managed clusters (AWS / Azure / GCP) have only the trace subject. Companion PR in `wandb/core` patches AWS + GCP single-tenant modules.

## Test plan
- [ ] `tflint --recursive` — clean (no new warnings introduced by this change).
- [ ] Cut a new tag (e.g. `v7.9.2-cw0`) for `wandb/core`'s `azure/single-tenant/main.tf` to pin against once merged.
- [ ] Repro previously confirmed on qa-azure by patching the CR manually; both subjects now in `GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS` and 401s have stopped.
- [ ] Verify post-apply: `kubectl get configmap -n default wandb-api-configmap -o jsonpath='{.data.GORILLA_INTERNAL_JWT_SUBJECTS_TO_ISSUERS}'` shows both subjects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend infrastructure authentication configuration to support additional service account management and JWT mappings, enabling enhanced worker process coordination in the cloud environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->