### PR TITLE
feat: Lumen value threading from TF to helm

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ resources that lack official modules.
 | <a name="input_kubernetes_node_disk_size_gb"></a> [kubernetes\_node\_disk\_size\_gb](#input\_kubernetes\_node\_disk\_size\_gb) | Size of the node root volume in GB. | `number` | `null` | no |
 | <a name="input_license"></a> [license](#input\_license) | Your wandb/local license | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
-| <a name="input_lumen_agent_wif_audience"></a> [lumen\_agent\_wif\_audience](#input\_lumen\_agent\_wif\_audience) | the audience for a dedicated customer's WIF pool for a lumen agent | `string` | n/a | yes |
-| <a name="input_lumen_data_root"></a> [lumen\_data\_root](#input\_lumen\_data\_root) | object storage to which config data is written | `string` | n/a | yes |
+| <a name="input_lumen_agent_wif_audience"></a> [lumen\_agent\_wif\_audience](#input\_lumen\_agent\_wif\_audience) | the audience for a dedicated customer's WIF pool for a lumen agent | `string` | `""` | no |
+| <a name="input_lumen_data_root"></a> [lumen\_data\_root](#input\_lumen\_data\_root) | object storage to which config data is written | `string` | `""` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | String used for prefix resources. | `string` | n/a | yes |
 | <a name="input_node_max_pods"></a> [node\_max\_pods](#input\_node\_max\_pods) | Maximum number of pods per node | `number` | `30` | no |
 | <a name="input_node_pool_num_zones"></a> [node\_pool\_num\_zones](#input\_node\_pool\_num\_zones) | Number of availability zones to use for the node pool when node\_pool\_zones is not set. If neither are set, 3 zones will be used | `number` | `2` | no |

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ resources that lack official modules.
 | <a name="input_kubernetes_node_disk_size_gb"></a> [kubernetes\_node\_disk\_size\_gb](#input\_kubernetes\_node\_disk\_size\_gb) | Size of the node root volume in GB. | `number` | `null` | no |
 | <a name="input_license"></a> [license](#input\_license) | Your wandb/local license | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
+| <a name="input_lumen_agent_wif_audience"></a> [lumen\_agent\_wif\_audience](#input\_lumen\_agent\_wif\_audience) | the audience for a dedicated customer's WIF pool for a lumen agent | `string` | n/a | yes |
+| <a name="input_lumen_data_root"></a> [lumen\_data\_root](#input\_lumen\_data\_root) | object storage to which config data is written | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | String used for prefix resources. | `string` | n/a | yes |
 | <a name="input_node_max_pods"></a> [node\_max\_pods](#input\_node\_max\_pods) | Maximum number of pods per node | `number` | `30` | no |
 | <a name="input_node_pool_num_zones"></a> [node\_pool\_num\_zones](#input\_node\_pool\_num\_zones) | Number of availability zones to use for the node pool when node\_pool\_zones is not set. If neither are set, 3 zones will be used | `number` | `2` | no |

--- a/main.tf
+++ b/main.tf
@@ -383,6 +383,13 @@ locals {
           external = false
         }
 
+        lumen = {
+          dataRoot = var.lumen_data_root
+          gcpWorkloadIdentity = {
+            audience = var.lumen_agent_wif_audience
+          }
+        }
+
         extraEnv = merge({
           "GORILLA_CUSTOMER_SECRET_STORE_AZ_CONFIG_VAULT_URI" = module.vault.vault.vault_uri,
           "GORILLA_CUSTOMER_SECRET_STORE_SOURCE"              = "az-secretmanager://wandb",

--- a/variables.tf
+++ b/variables.tf
@@ -424,9 +424,11 @@ variable "clickhouse_region" {
 variable "lumen_agent_wif_audience" {
   description = "the audience for a dedicated customer's WIF pool for a lumen agent"
   type        = string
+  default     = ""
 }
 
 variable "lumen_data_root" {
   description = "object storage to which config data is written"
   type        = string
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -416,3 +416,17 @@ variable "clickhouse_region" {
   description = "ClickHouse region (eastus2, westus3, etc)."
   default     = ""
 }
+
+#########
+# Lumen #
+#########
+
+variable "lumen_agent_wif_audience" {
+  description = "the audience for a dedicated customer's WIF pool for a lumen agent"
+  type        = string
+}
+
+variable "lumen_data_root" {
+  description = "object storage to which config data is written"
+  type        = string
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new Lumen configuration inputs for workload identity audience and the data storage root.
  * The deployment now forwards these Lumen settings into the chart values to apply them at runtime (with empty-string defaults).

* **Documentation**
  * Updated the README input reference to include `lumen_agent_wif_audience` and `lumen_data_root`, including their default values and “not required” status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->