### PR TITLE
fix(weave): Authorize future wandb-weave identity

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -410,6 +410,8 @@ locals {
           annotations = { "azure.workload.identity/client-id" = module.identity.identity.client_id }
           labels      = { "azure.workload.identity/use" = "true" }
         }
+        # Keep legacy Weave subjects during the shared-ServiceAccount rollout.
+        # Remove them only after every installation uses wandb-weave.
         internalJWTMap = [
           {
             subject = "system:serviceaccount:default:${local.weave_trace_service_account_name}",
@@ -417,6 +419,10 @@ locals {
           },
           {
             subject = "system:serviceaccount:default:${local.weave_trace_worker_service_account_name}",
+            issuer  = module.app_aks.oidc_issuer_url
+          },
+          {
+            subject = "system:serviceaccount:default:${local.k8s_sa_map.weave}",
             issuer  = module.app_aks.oidc_issuer_url
           },
         ]


### PR DESCRIPTION
## Phase 1: authorization bridge only

This published Azure module adds `system:serviceaccount:default:wandb-weave` to Gorilla's internal-JWT issuer map. It retains the existing trace and trace-worker subjects. It does **not** change a workload ServiceAccount.

## Deployment order

1. Deploy the companion [Core/Gorilla managed-install bridge](https://github.com/wandb/core/pull/49594) across the managed fleet.
2. Release this module for standalone Azure consumers.
3. Deploy the [Helm phase-1 consolidation](https://github.com/wandb/helm-charts/pull/672), which moves the trace-family workloads only to existing `wandb-weave-trace`.
4. Only in a later phase may those workloads move to `wandb-weave`; by then both Gorilla and every per-install map already accept it.

No Terraform plan or apply was run.

## Validation

- `terraform init -backend=false`
- `terraform validate`
- `terraform fmt -check main.tf modules/secure_storage_connector/service_accounts/main.tf`

Validation passed, with the repository-existing AzureRM storage queue-properties deprecation warning.

## Reachability

Core currently uses its vendored Azure module for managed installs, so the same bridge is included in Core. This PR is still required for published-module consumers.